### PR TITLE
Small changes to find error in fixTypeStability

### DIFF
--- a/src/simulations/functional_inversions/functional_inversion_utils.jl
+++ b/src/simulations/functional_inversions/functional_inversion_utils.jl
@@ -105,7 +105,8 @@ function loss_iceflow(θ, batch_ids::Vector{I}, simulation::FunctionalInversion)
             end
             # Ice surface velocities
             normVref = mean(Vx_ref.^2 .+ Vy_ref.^2)^0.5
-            l_V_loc = loss(Vx_pred, inn1(Vx_ref)) + loss(Vy_pred, inn1(Vy_ref))
+            # l_V_loc = loss(Vx_pred, inn1(Vx_ref)) + loss(Vy_pred, inn1(Vy_ref))
+            l_V_loc = loss(Vx_pred, Vx_ref) + loss(Vy_pred, Vy_ref)
             l_V += normVref^(-1) * l_V_loc
         else
             # Ice thickness
@@ -153,7 +154,8 @@ function batch_iceflow_UDE(θ, simulation::FunctionalInversion, batch_id::I) whe
 
     tstops = Huginn.define_callback_steps(params.simulation.tspan, params.solver.step)
     params.solver.tstops = tstops
-    stop_condition(u,t,integrator) = Sleipnir.stop_condition_tstops(u,t,integrator, Enzyme.Const(tstops)) #closure
+    # stop_condition(u,t,integrator) = Sleipnir.stop_condition_tstops(u,t,integrator, Enzyme.Const(tstops)) #closure
+    stop_condition(u,t,integrator) = Sleipnir.stop_condition_tstops(u,t,integrator, tstops)
     function action!(integrator)
         if params.simulation.use_MB 
             # Compute mass balance
@@ -209,8 +211,8 @@ function simulate_iceflow_UDE!(
     SIA2D_UDE_closure(H, θ, t) = SIA2D_UDE(H, θ, t, simulation, batch_id)
 
     # Constant definition of tstops with Enzyme returns error.
-    tstops = Enzyme.Const(params.solver.tstops) # Not clear if we need to make tstops constant, try to remove Enzyme.Const once AD is working
-    # tstops = params.solver.tstops
+    # tstops = Enzyme.Const(params.solver.tstops) # Not clear if we need to make tstops constant, try to remove Enzyme.Const once AD is working
+    tstops = params.solver.tstops
     
     iceflow_prob = ODEProblem(SIA2D_UDE_closure, model.iceflow[batch_id].H, params.simulation.tspan, tstops=tstops, θ)
     


### PR DESCRIPTION
@albangossard I created this small PR since I was trying to make your PR #231 to work. As I mentioned, the dummy gradient should work. A few weird things that I noticed here: 
- For some reason, the `inn1()` inside the computation of the loss function does not seem to be necesary anymore. Do you know why? I couldn't find any change affecting this. 
- It seems that `Enzyme.Const` really crashes stuff, even the dummy gradient. This is the reason I am not sure the segmentation fault you saw is coming from the pure AD problem, but of course I can be wrong. 

Now you will see that the inverse simulation with dummy grad works, but there is a problem: the parameter \theta does not get updated... this didn't happen before (notice one of the test actually checks there are updates in the parameter vector). Do you think some of the changes may have broke this?

Happy to keep debugging this together! I feel every PR bring us closer to a final solution!!!  