### PR TITLE
[WIP] Design of pipeline to save results from ML inversion

### DIFF
--- a/src/ODINN.jl
+++ b/src/ODINN.jl
@@ -86,4 +86,7 @@ include(joinpath(root_dir, "src/models/machine_learning/MLmodel.jl"))
 # Inversion for SIA equation
 include(joinpath(root_dir, "src/inverse/SIA2D/Inversion.jl"))
 
+# Results
+include(joinpath(root_dir, "src/results/Results.jl"))
+
 end # module

--- a/src/results/Results.jl
+++ b/src/results/Results.jl
@@ -1,0 +1,12 @@
+export Result
+export save_simulation_file!
+
+abstract type AbstractResult end
+
+@kwdef struct Result{F <: AbstractFloat} <: AbstractResult
+    θ::ComponentVector
+    losses::Vector{F}
+    params::Sleipnir.Parameters
+end
+
+include("result_utils.jl")

--- a/src/results/result_utils.jl
+++ b/src/results/result_utils.jl
@@ -1,0 +1,32 @@
+"""
+
+This function saves the results of a simulation to a file in JLD2 format. If the `path` argument is not provided, the function will create a default path based on the current project directory. The results are saved in a file named `prediction_<nglaciers>glaciers_<tspan>.jld2`, where `<nglaciers>` is the number of glaciers in the simulation and `<tspan>` is the simulation time span.
+"""
+function save_simulation_file!(
+    sol,
+    simulation::SIM;
+    path::Union{String,Nothing} = nothing,
+    file_name::Union{String,Nothing} = nothing
+    ) where {SIM <: Simulation}
+
+    # Create path for simulation results
+    if isnothing(path)
+        simulation_path = joinpath(dirname(Base.current_project()), "data/results/simulation")
+    else
+        simulation_path = path
+    end
+    if !ispath(simulation_path)
+        mkpath(simulation_path)
+    end
+
+    res = ODINN.Result(
+        θ = sol.u,
+        losses = simulation.stats.losses,
+        params = simulation.parameters
+    )
+
+    # Save results
+    jldsave(joinpath(simulation_path, file_name); res)
+
+    return nothing
+end

--- a/src/simulations/functional_inversions/functional_inversion_utils.jl
+++ b/src/simulations/functional_inversions/functional_inversion_utils.jl
@@ -13,7 +13,11 @@ This function initiates the training of a Universal Differential Equation (UDE) 
 - The `Sleipnir.save_results_file!` function call is currently commented out and should be enabled once the optimization process is confirmed to be working.
 - The garbage collector is explicitly run using `GC.gc()` to manage memory usage.
 """
-function run!(simulation::FunctionalInversion)
+function run!(
+    simulation::FunctionalInversion;
+    path::Union{String, Nothing} = nothing,
+    file_name::Union{String, Nothing} = nothing
+    )
 
     println("Running training of UDE...\n")
 
@@ -46,7 +50,10 @@ function run!(simulation::FunctionalInversion)
     simulation.stats.θ = sol.u
 
     # TODO: Save when optimization is working
-    # Sleipnir.save_results_file!(results_list, simulation)
+    # Save results in path is provided
+    if !isnothing(path) & !isnothing(file_name)
+        ODINN.save_simulation_file!(sol, simulation; path = path, file_name = file_name)
+    end
 
     @everywhere GC.gc() # run garbage collector
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,7 @@ include("inversion_test.jl")
 include("SIA2D_adjoint.jl")
 include("test_grad_loss.jl")
 include("test_grad_Enzyme.jl")
+include("save_results.jl")
 
 # # Activate to avoid GKS backend Plot issues in the JupyterHub
 ENV["GKSwstype"] = "nul"
@@ -81,5 +82,7 @@ end
     @testset "Inversion Tests (without MB)" inversion_test(use_MB = false, steady_state = true, save_refs = false)
     @testset "Inversion Tests (with MB)" inversion_test(use_MB = true, steady_state = true, save_refs = false)
 end
+
+@testset "Save results" save_simulation_test!()
 
 end

--- a/test/save_results.jl
+++ b/test/save_results.jl
@@ -1,0 +1,68 @@
+function save_simulation_test!()
+
+    rgi_ids = ["RGI60-08.00203"]
+    rgi_paths = get_rgi_paths()
+    working_dir = joinpath(ODINN.root_dir, "test/data")
+    δt = 1/12
+
+    params = Parameters(
+        simulation = SimulationParameters(
+            use_MB = false,
+            velocities = true,
+            tspan = (2010.0, 2015.0),
+            step = δt,
+            working_dir = working_dir,
+            multiprocessing = false,
+            workers = 1,
+            test_mode = false,
+            rgi_paths = rgi_paths,
+        ),
+        hyper = Hyperparameters(
+            batch_size = length(rgi_ids), # We set batch size equals all datasize so we test gradient
+            epochs = 1,
+            optimizer = ODINN.ADAM(0.01),
+            ),
+        UDE = UDEparameters(
+            optim_autoAD = ODINN.NoAD(),
+            grad = ContinuousAdjoint(),
+            target = :A
+        ),
+        solver = Huginn.SolverParameters(
+            step = δt,
+            save_everystep = true,
+            progress = true
+            )
+    )
+
+    model = Model(
+        iceflow = SIA2Dmodel(params, C=0.0),
+        mass_balance = TImodel1(params),
+        machine_learning = NeuralNetwork(params)
+    )
+
+    glaciers = initialize_glaciers(rgi_ids, params)
+
+    tstops = collect(2010:δt:2015)
+    ODINN.generate_ground_truth(glaciers, :PatersonCuffey, params, model, tstops)
+
+    functional_inversion = FunctionalInversion(model, glaciers, params)
+
+    path = joinpath(ODINN.root_dir, "test/data")
+    file_name = "simulation_results.jld2"
+    run!(functional_inversion; path = path, file_name = file_name)
+
+    # Load results
+    res_load = load(joinpath(ODINN.root_dir, path, file_name), "res")
+
+    # Obtain parameters of model
+    θ_load = res_load.θ
+    losses_load = res_load.losses
+    params_load = res_load.params
+
+    @test !isnothing(res_load)
+    @test θ_load ≈ functional_inversion.stats.θ
+    @test length(losses_load) == functional_inversion.stats.niter
+    @test params_load.hyper.epochs == params.hyper.epochs
+end
+
+


### PR DESCRIPTION
@albangossard as I am running simulation for the inversion of the diffusivity D, I thought it was going to be useful to figure out how to save relevant outputs of the simulation so these can be analyze later. The most important of these, the trained parameters of the neural network to allow post evaluation. This PR is trying to address this.

Notice that Sleipnir also has a save results function, but this is rather different in nature than saving the information of the model (rather than the information of a forward SIA simulation). What do you think? 

This PR is work in progress, so it would be nice to think (assuming we approved the API design) what else we would like to save. Notice that the architecture of the NN will be harder to save, so maybe we want to think about this. 

So far, this PR has

- Design of simple Results object
- Save of such object at the end of simulation in `jld2` format
- A test to assess that the file is saving the information correctly

Any feedback welcome!