### PR TITLE
Split discrete VJPs into two seperate functions

### DIFF
--- a/src/inverse/SIA2D/VJPs.jl
+++ b/src/inverse/SIA2D/VJPs.jl
@@ -1,6 +1,6 @@
 
 function VJP_λ_∂SIA∂H(VJPMode::DiscreteVJP, λ, H, θ, simulation::Simulation, t)
-    λ_∂f∂H = VJP_λ_∂SIA_discrete(λ, H, θ, simulation, t)[1]
+    λ_∂f∂H = VJP_λ_∂SIA∂H_discrete(λ, H, θ, simulation, t)
     return λ_∂f∂H, nothing
 end
 
@@ -28,7 +28,7 @@ function VJP_λ_∂SIA∂H(VJPMode::EnzymeVJP, λ, H, θ, simulation::Simulation
 end
 
 function VJP_λ_∂SIA∂θ(VJPMode::DiscreteVJP, λ, H, θ, dH_H, simulation::Simulation, t)
-    λ_∂f∂θ = VJP_λ_∂SIA_discrete(λ, H, θ, simulation, t)[2]
+    λ_∂f∂θ = VJP_λ_∂SIA∂θ_discrete(λ, H, θ, simulation, t)
     return λ_∂f∂θ
 end
 

--- a/src/inverse/SIA2D/adjoint.jl
+++ b/src/inverse/SIA2D/adjoint.jl
@@ -1,4 +1,4 @@
-export VJP_λ_∂SIA_discrete
+export VJP_λ_∂SIA∂H_discrete, VJP_λ_∂SIA∂θ_discrete
 export VJP_λ_∂SIA∂H_continuous, VJP_λ_∂SIA∂θ_continuous
 
 
@@ -7,31 +7,28 @@ export VJP_λ_∂SIA∂H_continuous, VJP_λ_∂SIA∂θ_continuous
 #######################################
 
 """
-    VJP_λ_∂SIA_discrete(
-        ∂dH::Matrix{R},
+    VJP_λ_∂SIA∂H_discrete(
+        λ::Matrix{R},
         H::Matrix{R},
         θ,
         simulation::SIM,
         t::R,
     ) where {R <:Real, SIM <: Simulation}
 
-Compute an out-of-place adjoint step of the Shallow Ice Approximation PDE.
-Given an output gradient, it backpropagates the gradient to the inputs H and A.
-To some extent, this function is equivalent to VJP_λ_∂SIA∂H_continuous and
-VJP_λ_∂SIA∂θ_continuous.
+Implementation of the discrete VJP of the SIA2D equation with respect to H.
+Given λ and H, it returns the VJP of λ^T * ∂(SIA2D)/∂H (H).
 
 Arguments:
-- `∂dH::Matrix{R}`: Output gradient to backpropagate.
+- `λ::Matrix{R}`: Adjoint state, also called output gradient in reverse-mode AD.
 - `H::Matrix{R}`: Ice thickness which corresponds to the input state of the SIA2D.
 - `simulation::SIM`: Simulation parameters.
 - `t::R`: Time value, not used as SIA2D is time independent.
 
 Returns:
-- `∂H::Matrix{R}`: Input gradient wrt H.
-- `∂A::F`: Input gradient wrt A.
+- `dλ::Matrix{R}`: Jacobian vector product, also called input gradient in reverse-mode AD.
 """
-function VJP_λ_∂SIA_discrete(
-    ∂dH::Matrix{R},
+function VJP_λ_∂SIA∂H_discrete(
+    λ::Matrix{R},
     H::Matrix{R},
     θ,
     simulation::SIM,
@@ -97,9 +94,9 @@ function VJP_λ_∂SIA_discrete(
     Dx = Huginn.avg_y(D)
     Dy = Huginn.avg_x(D)
 
-    ∂dH_inn = ∂dH[2:end-1,2:end-1]
-    Fx_adjoint = diff_x_adjoint(-∂dH_inn, Δx)
-    Fy_adjoint = diff_y_adjoint(-∂dH_inn, Δy)
+    λ_inn = λ[2:end-1,2:end-1]
+    Fx_adjoint = diff_x_adjoint(-λ_inn, Δx)
+    Fy_adjoint = diff_y_adjoint(-λ_inn, Δy)
     Dx_adjoint = avg_y_adjoint(-Fx_adjoint .* dSdx_edges_clamp)
     Dy_adjoint = avg_x_adjoint(-Fy_adjoint .* dSdy_edges_clamp)
     D_adjoint = Dx_adjoint + Dy_adjoint
@@ -141,8 +138,98 @@ function VJP_λ_∂SIA_discrete(
     ∂C∂H_adj = ∂C∂H_adj_x + ∂C∂H_adj_y
 
     # Sum contributions of diffusivity and clipping
-    ∂H = ∂D∂H_adj + ∂C∂H_adj
-    ∂H .= ∂H.*(H.>0)
+    dλ = ∂D∂H_adj + ∂C∂H_adj
+    dλ .= dλ.*(H.>0)
+
+    return dλ
+end
+
+
+"""
+    VJP_λ_∂SIA∂θ_discrete(
+        λ::Matrix{R},
+        H::Matrix{R},
+        θ,
+        simulation::SIM,
+        t::R,
+    ) where {R <: Real, SIM <: Simulation}
+
+Implementation of the discrete VJP of the SIA2D equation with respect to θ.
+Given λ, H and θ, it returns the VJP of λ^T * ∂(SIA2D)/∂θ (θ).
+
+Arguments:
+- `θ`: Vector of parameters
+- `λ::Matrix{R}`: Adjoint state, also called output gradient in reverse-mode AD.
+- `H::Matrix{R}`: Ice thickness which corresponds to the input state of the SIA2D.
+- `simulation::SIM`: Simulation parameters.
+- `t::R`: Time value, not used as SIA2D is time independent.
+
+Returns:
+- `∂θ`: Jacobian vector product with respect to θ, also called input gradient in
+    reverse-mode AD. It has the same type as θ.
+"""
+function VJP_λ_∂SIA∂θ_discrete(
+    λ::Matrix{R},
+    H::Matrix{R},
+    θ,
+    simulation::SIM,
+    t::R,
+) where {R <:Real, SIM <: Simulation}
+
+    SIA2D_model = simulation.model.iceflow
+    SIA2D_cache = simulation.cache.iceflow
+    glacier_idx = SIA2D_cache.glacier_idx
+    glacier = simulation.glaciers[glacier_idx]
+
+    # Retrieve models and parameters
+    params = simulation.parameters
+    target = simulation.model.machine_learning.target
+
+    B = glacier.B
+    Δx = glacier.Δx
+    Δy = glacier.Δy
+
+    # First, enforce values to be positive
+    map!(x -> ifelse(x > 0.0, x, 0.0), H, H)
+    # Update glacier surface altimetry
+    S = B .+ H
+
+    # All grid variables computed in a staggered grid
+    # Compute surface gradients on edges
+    dSdx = Huginn.diff_x(S)/Δx
+    dSdy = Huginn.diff_y(S)/Δy
+    ∇Sx = Huginn.avg_y(dSdx)
+    ∇Sy = Huginn.avg_x(dSdy)
+
+    # Compute surface slope
+    ∇S = (∇Sx.^2 .+ ∇Sy.^2).^(1/2)
+
+    # Compute average ice thickness
+    H̄ = Huginn.avg(H)
+
+    # Store temporary variables for use with the laws
+    SIA2D_cache.∇S .= ∇S
+    SIA2D_cache.H̄ .= H̄
+
+    θ = isnothing(simulation.model.machine_learning) ? nothing : simulation.model.machine_learning.θ
+    Huginn.apply_all_non_callback_laws!(SIA2D_model, SIA2D_cache, simulation, glacier_idx, t, θ)
+
+    # Compute flux components
+    @views dSdx_edges = Huginn.diff_x(S[:,2:end - 1]) / Δx
+    @views dSdy_edges = Huginn.diff_y(S[2:end - 1,:]) / Δy
+
+    # Cap surface elevaton differences with the upstream ice thickness to
+    # imporse boundary condition of the SIA equation
+    η₀ = params.physical.η₀
+    dSdx_edges_clamp = clamp_borders_dx(dSdx_edges, H, η₀, Δx)
+    dSdy_edges_clamp = clamp_borders_dy(dSdy_edges, H, η₀, Δy)
+
+    λ_inn = λ[2:end-1,2:end-1]
+    Fx_adjoint = diff_x_adjoint(-λ_inn, Δx)
+    Fy_adjoint = diff_y_adjoint(-λ_inn, Δy)
+    Dx_adjoint = avg_y_adjoint(-Fx_adjoint .* dSdx_edges_clamp)
+    Dy_adjoint = avg_x_adjoint(-Fy_adjoint .* dSdy_edges_clamp)
+    D_adjoint = Dx_adjoint + Dy_adjoint
 
     # Gradient wrt θ
     ∂D∂θ = ∂Diffusivity∂θ(
@@ -156,7 +243,7 @@ function VJP_λ_∂SIA_discrete(
     # Construct component vector
     ∂θ = Vector2ComponentVector(∂θ_v, θ)
 
-    return ∂H, ∂θ
+    return ∂θ
 end
 
 
@@ -330,7 +417,8 @@ end
         simulation::SIM,
         t::R,
     ) where {R <: Real, SIM <: Simulation}
-Implementation of the continuous adjoint of the SIA2D equation with respect to H.
+
+Implementation of the continuous VJP of the SIA2D equation with respect to H.
 Given λ and H, it returns the VJP of λ^T * ∂(SIA2D)/∂H (H).
 
 Arguments:
@@ -464,7 +552,8 @@ end
         simulation::SIM,
         t::R,
     ) where {R <: Real, SIM <: Simulation}
-Implementation of the continuous adjoint of the SIA2D equation with respect to θ.
+
+Implementation of the continuous VJP of the SIA2D equation with respect to θ.
 Given λ, H and θ, it returns the VJP of λ^T * ∂(SIA2D)/∂θ (θ).
 
 Arguments:
@@ -475,7 +564,8 @@ Arguments:
 - `t::R`: Time value, not used as SIA2D is time independent.
 
 Returns:
-- `dλ::Matrix{R}`: Jacobian vector product, also called input gradient in reverse-mode AD.
+- `∂θ`: Jacobian vector product with respect to θ, also called input gradient in
+    reverse-mode AD. It has the same type as θ.
 """
 function VJP_λ_∂SIA∂θ_continuous(
     λ::Matrix{R},


### PR DESCRIPTION
We now have very similar runtimes between the discrete and continuous VJPs:
<img width="1513" height="500" alt="image" src="https://github.com/user-attachments/assets/46e9a05b-c7d2-4a86-a2f4-f7857fc3ade9" />
