### PR TITLE
Changes in how Target and Law API interact for Custom Inversion Laws

### DIFF
--- a/src/inverse/SIA2D/gradient.jl
+++ b/src/inverse/SIA2D/gradient.jl
@@ -97,6 +97,7 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
         tstopsDiscreteLoss = unique(discreteLossSteps(params.UDE.empirical_loss_function, tspan))
         tstops = sort(unique(vcat(
             tstops, params.solver.tstops, tH_ref, tV_ref, tstopsDiscreteLoss)))
+        tstops = tstops[tspan[1] .<= tstops .<= tspan[2]]
 
         @assert length(t) == length(tstops) "The size of tstops does not match with the size of the reference times."
         @assert isapprox(t, tstops, rtol = 1e-7) "Times in tstops and reference times in result do not coincide. Maximum difference is $(maximum(abs.(t-tstops)))"
@@ -294,6 +295,7 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
                 function (t, u)
                     indThickness = findfirst(==(t), tH_ref)
                     indVelocity = findfirst(==(t), tV_ref)
+                    @infiltrate
                     Δtj = (;
                         H = isnothing(indThickness) ? 0.0 :
                             safe_slice(Δt_HV.H, indThickness - 1),

--- a/src/inverse/SIA2D/gradient.jl
+++ b/src/inverse/SIA2D/gradient.jl
@@ -249,7 +249,9 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
             Notice this should not be an issue since t ≈ tH_ref
             """
             if simulation.parameters.UDE.grad.interpolation == :Linear
-                H_itp = interpolate((t,), H, Gridded(Linear()))
+                # We use duplicated_knots since sometimes the solution of the solver includes
+                # t values too close to each other.
+                H_itp = interpolate((Interpolations.deduplicate_knots!(t),), H, Gridded(Linear()))
                 H_ref_itp = useThickness ?
                             interpolate((tH_ref,), H_ref, Gridded(Linear())) : nothing
                 Vabs_ref_itp = useVelocity ?

--- a/src/inverse/SIA2D/gradient.jl
+++ b/src/inverse/SIA2D/gradient.jl
@@ -295,12 +295,11 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
                 function (t, u)
                     indThickness = findfirst(==(t), tH_ref)
                     indVelocity = findfirst(==(t), tV_ref)
-                    @infiltrate
                     Δtj = (;
                         H = isnothing(indThickness) ? 0.0 :
                             safe_slice(Δt_HV.H, indThickness - 1),
                         V = isnothing(indVelocity) ? 0.0 :
-                            safe_slice(Δt_HV.H, indVelocity - 1)
+                            safe_slice(Δt_HV.V, indVelocity - 1)
                     )
                     ∂ℓ∂H,
                     ∂ℓ∂θ = backward_loss(

--- a/src/laws/Cache.jl
+++ b/src/laws/Cache.jl
@@ -35,6 +35,7 @@ mutable struct MatrixCacheInterp <: Cache
         },
         Tuple{Vector{Float64}, Vector{Float64}}
     }
+    vjp_θ::Array{Float64, 3}
 end
 
 """

--- a/src/laws/Laws.jl
+++ b/src/laws/Laws.jl
@@ -141,7 +141,8 @@ function LawU(
             zeros(nx - 1, ny - 1),
             H_nodes,
             H_nodes,
-            grad_itp
+            grad_itp,
+            Array{Sleipnir.Float64}(undef, nx - 1, ny - 1, length(θ)),
         )
     end
     init_cache_matrix = function (simulation, glacier_idx, θ)
@@ -168,6 +169,15 @@ function LawU(
         end
     end
 
+    f_VJP_θ! = function (cache, inp, θ)
+        # Unpack gradient interpolation
+        grad_itp = cache.interp_θ
+        (; H̄, ∇S) = inp
+        for i in axes(H̄, 1), j in axes(H̄, 2)
+            cache.vjp_θ[i, j, :] = grad_itp(H̄[i, j], ∇S[i, j])
+        end
+    end
+
     # Determine right type of cache depending of interpolation or not
     LawCache = precompute_interpolation ? MatrixCacheInterp : MatrixCache
 
@@ -176,7 +186,9 @@ function LawU(
             inputs = (; H̄ = iH̄(), ∇S = i∇S()),
             f! = f!,
             init_cache = precompute_interpolation ? init_cache_interp : init_cache_matrix,
-            p_VJP! = precompute_VJPs ? p_VJP! : nothing
+            p_VJP! = precompute_VJPs ? p_VJP! : nothing,
+            f_VJP_θ! = f_VJP_θ!, # When providing with one of these, also need to provide the next one!!!
+            f_VJP_input! = function () end,
         )
     end
     return U_law

--- a/src/losses/Losses.jl
+++ b/src/losses/Losses.jl
@@ -137,7 +137,7 @@ function loss(
         mask::BitMatrix,
         normalization::F
 ) where {F <: AbstractFloat}
-    return sum(((a .- b)[mask]) .^ 2)/normalization
+    return Sleipnir.nansum(((a .- b)[mask]) .^ 2)/normalization
 end
 function backward_loss(
         lossType::L2Sum,
@@ -148,6 +148,8 @@ function backward_loss(
 ) where {F <: AbstractFloat}
     d = zero(a)
     d[mask] = a[mask] .- b[mask]
+    # We replace nan values coming from missing data
+    d = replace(d, NaN => 0)
     return 2.0 .* d ./ normalization
 end
 

--- a/src/losses/Losses.jl
+++ b/src/losses/Losses.jl
@@ -314,7 +314,11 @@ function loss(
     Vx_pred, Vy_pred, V_pred = Huginn.V_from_H(simulation, H_pred, t, θ)
     # TODO: in the future we should dispatch wrt the iceflow model
 
-    mask = (V_ref .> 0.0)
+    mask = if length(simulation.glaciers[1].mask_loss) > 0
+        simulation.glaciers[1].mask_loss
+    else
+        V_ref .> 0.0
+    end
 
     ℓ = if lossType.component == :xy
         loss(lossType.loss, Vx_pred, Vx_ref, mask, normalization) +
@@ -358,7 +362,11 @@ function backward_loss(
     Vx_pred, Vy_pred, V_pred = Huginn.V_from_H(simulation, H_pred, t, θ)
     # TODO: in the future we should dispatch wrt the iceflow model
 
-    mask = (V_ref .> 0.0)
+    mask = if length(simulation.glaciers[1].mask_loss) > 0
+        simulation.glaciers[1].mask_loss
+    else
+        V_ref .> 0.0
+    end
 
     if lossType.component == :xy
         ∂lV∂Vx = backward_loss(lossType.loss, Vx_pred, Vx_ref, mask, normalization)

--- a/src/models/target/target_D_pure.jl
+++ b/src/models/target/target_D_pure.jl
@@ -95,11 +95,16 @@ function Diffusivity(
     return D
 end
 
-function eval_U(target::SIA2D_D_target, H̄, ∇S, θ, simulation)
-    iceflow_cache = simulation.cache.iceflow
-    iceflow_model = simulation.model.iceflow
-    iceflow_model.U.f.f(iceflow_cache.U, (; H̄ = H̄, ∇S = ∇S), θ)
-    return iceflow_cache.U.value
+function eval_U(
+    target::SIA2D_D_target;
+    H̄, ∇S, θ, simulation, glacier_idx, t, glacier, params
+)
+    iceflow_cache = simulation.cache.iceflow.U
+    iceflow_model = simulation.model.iceflow.U
+
+    apply_law!(iceflow_model, iceflow_cache, simulation, glacier_idx, t, θ)
+
+    return iceflow_cache.value
 end
 
 function ∂Diffusivity∂H(
@@ -112,8 +117,8 @@ function ∂Diffusivity∂H(
     δH = 1e-4 .* ones(size(H̄))
 
     # TODO: This can also be replace by interpolation
-    D₊ = eval_U(target, H̄ + δH, ∇S, θ, simulation) .* (H̄ + δH)
-    D₋ = eval_U(target, H̄ - δH, ∇S, θ, simulation) .* (H̄ - δH)
+    D₊ = eval_U(target; H̄ = H̄ + δH, ∇S = ∇S, θ = θ, simulation = simulation, glacier_idx = glacier_idx, t = t, glacier = glacier, params = params) .* (H̄ + δH)
+    D₋ = eval_U(target; H̄ = H̄ - δH, ∇S = ∇S, θ = θ, simulation = simulation, glacier_idx = glacier_idx, t = t, glacier = glacier, params = params) .* (H̄ - δH)
 
     # Compute central difference derivative
     ∂D∂H_NN = (D₊ .- D₋) ./ (2.0 .* δH)
@@ -128,8 +133,8 @@ function ∂Diffusivity∂∇H(
     δ∇H = 1e-6 .* ones(size(∇S))
 
     # TODO: This can also be replaced by interpolation
-    D₊ = eval_U(target, H̄, ∇S + δ∇H, θ, simulation) .* H̄
-    D₋ = eval_U(target, H̄, ∇S - δ∇H, θ, simulation) .* H̄
+    D₊ = eval_U(target; H̄ = H̄, ∇S = ∇S + δ∇H, θ = θ, simulation = simulation, glacier_idx = glacier_idx, t = t, glacier = glacier, params = params) .* H̄
+    D₋ = eval_U(target; H̄ = H̄, ∇S = ∇S - δ∇H, θ = θ, simulation = simulation, glacier_idx = glacier_idx, t = t, glacier = glacier, params = params) .* H̄
 
     # Compute central difference derivative
     ∂D∂∇S = (D₊ .- D₋) ./ (2.0 .* δ∇H)
@@ -184,12 +189,12 @@ function ∂U∂θ(
         the desired level of precision for the gradients.
         We construct an interpolator with quantiles and equal-spaced points.
         """
-        # Unpack gradient interpolation
-        grad_itp = iceflow_cache.U.interp_θ
         # Compute spatial distributed gradient
+        inputs = generate_inputs(iceflow_model.U.f.inputs, simulation, glacier_idx, t)
+        ∂law∂θ!(backend, iceflow_model.U, iceflow_cache.U,
+            iceflow_cache.U_prep_vjps, inputs, θ)
         for i in axes(H̄, 1), j in axes(H̄, 2)
-            # Include extra contribution of ice thickness H
-            ∂D∂θ[i, j, :] .= ∂spatial[i, j] * grad_itp(H̄[i, j], ∇S[i, j])
+            ∂D∂θ[i, j, :] .= ∂spatial[i, j] * iceflow_cache.U.vjp_θ[i, j, :]
         end
     else
         throw("Method to spatially compute gradient with respect to H̄ not specified.")
@@ -221,8 +226,8 @@ function ∂Velocityꜛ∂H(
 )
     f = simulation.parameters.simulation.f_surface_velocity_factor
     δH = 1e-4 .* ones(size(H̄))
-    U₊ = eval_U(target, H̄ + δH, ∇S, θ, simulation)
-    U₋ = eval_U(target, H̄ - δH, ∇S, θ, simulation)
+    U₊ = eval_U(target; H̄ = H̄ + δH, ∇S = ∇S, θ = θ, simulation = simulation, glacier_idx = glacier_idx, t = t, glacier = glacier, params = params)
+    U₋ = eval_U(target; H̄ = H̄ - δH, ∇S = ∇S, θ = θ, simulation = simulation, glacier_idx = glacier_idx, t = t, glacier = glacier, params = params)
 
     # Compute central difference derivative
     ∂D∂Hꜛ = (1/f) * (U₊ .- U₋) ./ (2.0 .* δH)
@@ -235,8 +240,8 @@ function ∂Velocityꜛ∂∇H(
 )
     f = simulation.parameters.simulation.f_surface_velocity_factor
     δ∇H = 1e-6 .* ones(size(∇S))
-    U₊ = eval_U(target, H̄, ∇S + δ∇H, θ, simulation)
-    U₋ = eval_U(target, H̄, ∇S - δ∇H, θ, simulation)
+    U₊ = eval_U(target; H̄ = H̄, ∇S = ∇S + δ∇H, θ = θ, simulation = simulation, glacier_idx = glacier_idx, t = t, glacier = glacier, params = params)
+    U₋ = eval_U(target; H̄ = H̄, ∇S = ∇S - δ∇H, θ = θ, simulation = simulation, glacier_idx = glacier_idx, t = t, glacier = glacier, params = params)
 
     # Compute central difference derivative
     ∂D∂∇Hꜛ = (1/f) * (U₊ .- U₋) ./ (2.0 .* δ∇H)

--- a/src/models/trainable_components/Model.jl
+++ b/src/models/trainable_components/Model.jl
@@ -80,7 +80,8 @@ function Model(
     # Check that the inputs match what is hardcoded in the adjoint computation when the regressor is used in the context of a functional inversion
     if iceflow.U_is_provided
         if haskey(regressors, :U) && regressors.U isa FunctionalModel
-            @assert inputs(iceflow.U)==_inputs_U_law "Inputs of U law must be $(_inputs_U_law) in ODINN for functional inversions but the ones provided are $(inputs(iceflow.U))."
+            # TODO: Notice that this is a bit hardcoded, and it restricts a lot custom inversions!
+            # @assert inputs(iceflow.U)==_inputs_U_law "Inputs of U law must be $(_inputs_U_law) in ODINN for functional inversions but the ones provided are $(inputs(iceflow.U))."
         end
     elseif iceflow.Y_is_provided
         if haskey(regressors, :Y) && regressors.Y isa FunctionalModel

--- a/src/simulations/inversions/callback_utils.jl
+++ b/src/simulations/inversions/callback_utils.jl
@@ -80,8 +80,6 @@ function callback_diagnosis(θ, l, simulation; save::Bool = false,
             improvement = (l - simulation.results.stats.losses[end - step]) /
                           simulation.results.stats.losses[end - step]
         end
-        # printProgressLoss(length(simulation.results.stats.losses),
-            # simulation.results.stats.niter, l, improvement)
         printProgressLoss(iter,
             simulation.results.stats.niter, l, improvement)
     end

--- a/src/simulations/inversions/callback_utils.jl
+++ b/src/simulations/inversions/callback_utils.jl
@@ -80,7 +80,7 @@ function callback_diagnosis(θ, l, simulation; save::Bool = false,
             improvement = (l - simulation.results.stats.losses[end - step]) /
                           simulation.results.stats.losses[end - step]
         end
-        printProgressLoss(iter,
+        printProgressLoss(length(simulation.results.stats.losses),
             simulation.results.stats.niter, l, improvement)
     end
 

--- a/src/simulations/inversions/callback_utils.jl
+++ b/src/simulations/inversions/callback_utils.jl
@@ -65,9 +65,12 @@ function callback_diagnosis(θ, l, simulation; save::Bool = false,
     # See if we want to change this or leave it
     # update_training_state!(simulation, l)
 
-    push!(simulation.results.stats.losses, l)
-    push!(simulation.results.stats.θ_hist, θ.u)
-    push!(simulation.results.stats.∇θ_hist, θ.grad)
+    iter = θ.iter
+
+    # We save a copy of the state parameters as these are stored as a reference
+    push!(simulation.results.stats.losses, copy(l))
+    push!(simulation.results.stats.θ_hist, copy(θ.u))
+    push!(simulation.results.stats.∇θ_hist, copy(θ.grad))
 
     step = 1
     if length(simulation.results.stats.losses) % step == 0
@@ -77,7 +80,9 @@ function callback_diagnosis(θ, l, simulation; save::Bool = false,
             improvement = (l - simulation.results.stats.losses[end - step]) /
                           simulation.results.stats.losses[end - step]
         end
-        printProgressLoss(length(simulation.results.stats.losses),
+        # printProgressLoss(length(simulation.results.stats.losses),
+            # simulation.results.stats.niter, l, improvement)
+        printProgressLoss(iter,
             simulation.results.stats.niter, l, improvement)
     end
 

--- a/src/simulations/inversions/inversion_utils.jl
+++ b/src/simulations/inversions/inversion_utils.jl
@@ -29,20 +29,28 @@ function run!(
             Dates.format(now(), "yyyy-mm-dd_HH:MM:SS")
         )
 )
+    n_optimizers = if !(typeof(simulation.parameters.hyper.optimizer) <: Vector)
+        1
+    else
+        length(simulation.parameters.hyper.epochs)
+    end
+
     # Set expected total number of epochs from beginning for the callback
-    simulation.results.stats.niter = sum(simulation.parameters.hyper.epochs)
+    # Each optimizer makes one extra step to store the final parameter, so we include one
+    # extra epoch per used optimizer
+    simulation.results.stats.niter = sum(simulation.parameters.hyper.epochs) + n_optimizers
 
     logger = isnothing(path_tb_logger) || simulation.parameters.simulation.test_mode ?
              nothing : TBLogger(path_tb_logger)
-    if !(typeof(simulation.parameters.hyper.optimizer) <: Vector)
+    if n_optimizers == 1
         # One single optimizer
         sol = train_UDE!(simulation; save_every_iter = save_every_iter, logger = logger)
     else
         # Multiple optimizers
         optimizers = simulation.parameters.hyper.optimizer
         epochs = simulation.parameters.hyper.epochs
-        @assert length(optimizers) == length(epochs) "Provide number of epochs as a vector with the same length of optimizers"
-        for i in 1:length(epochs)
+        @assert length(optimizers) == n_optimizers "Provide number of epochs as a vector with the same length of optimizers"
+        for i in 1:n_optimizers
             # Construct a new simulation for each optimizer
             simulation.parameters.hyper.optimizer = optimizers[i]
             simulation.parameters.hyper.epochs = epochs[i]
@@ -52,7 +60,7 @@ function run!(
             end
             sol = train_UDE!(simulation; save_every_iter = save_every_iter, logger = logger)
             # Clear results of previous simulation for fresh start
-            if i < length(epochs)
+            if i < n_optimizers
                 simulation.results.simulation = Sleipnir.Results{Float64, Int64}[]
             end
         end

--- a/src/simulations/inversions/inversion_utils.jl
+++ b/src/simulations/inversions/inversion_utils.jl
@@ -495,6 +495,9 @@ function _batch_iceflow_UDE(
     tstopsVelocity = tdata(glacier.velocityData, params.simulation.mapping)
     tstopsDiscreteLoss = unique(discreteLossSteps(params.UDE.empirical_loss_function, params.simulation.tspan))
     tstops = sort(unique(vcat(tstops, tstopsIceThickness, tstopsVelocity, tstopsDiscreteLoss)))
+    # Filter tstops outside range of simulation
+    tmin, tmax = params.simulation.tspan
+    tstops = tstops[tmin .<= tstops .<= tmax]
 
     # Create mass balance callback
     cb_MB = if params.simulation.use_MB


### PR DESCRIPTION
This PR includes a series of improvements with respect to how the target and law interact. This changes aim to make work a general custom inversion law implemented outside ODINN with potentially arbitrary inputs. 

1. Changes how diffusivity and diffusivity gradients are called inside Target. Operations are moved inside Law
2. Adds nan statistics to losses to deal with missing values (to be discussed!)