### PR TITLE
speed-up custom NN test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -202,15 +202,16 @@ ENV["GKSwstype"] = "nul"
                 thres = [5e-3, 1e-6, 5e-3], target = :D, loss = LossV())
         end
     end
-    if (GROUP == "All" && (!CI || !Sys.isapple())) || GROUP == "Core7"
-        # Skip this test on macOS when running the "Full tests" CI because it is too slow and produces a timeout error (>6h)
-        @testset "Adjoint method of SIA equation with pure D as target and custom NN" begin
-            # @testset "Manual implementation of the continuous adjoint with discrete VJP and custom NN vs finite differences" test_grad_finite_diff(ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [1e-3, 1e-7, 1e-3], target = :D, custom_NN = true)
-            @testset "Manual implementation of the continuous adjoint with discrete VJP and custom NN vs finite differences (loss V)" test_grad_finite_diff(
-                ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [5e-3, 1e-7, 5e-3],
-                target = :D, custom_NN = true, loss = LossV())
-        end
-    end
+    # Skip this test because it consumes too much memory which leads to Jula being killed in the CI
+    # if (GROUP == "All" && (!CI || !Sys.isapple())) || GROUP == "Core7"
+    #     # Skip this test on macOS when running the "Full tests" CI because it is too slow and produces a timeout error (>6h)
+    #     @testset "Adjoint method of SIA equation with pure D as target and custom NN" begin
+    #         # @testset "Manual implementation of the continuous adjoint with discrete VJP and custom NN vs finite differences" test_grad_finite_diff(ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [1e-3, 1e-7, 1e-3], target = :D, custom_NN = true)
+    #         @testset "Manual implementation of the continuous adjoint with discrete VJP and custom NN vs finite differences (loss V)" test_grad_finite_diff(
+    #             ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [5e-3, 1e-7, 5e-3],
+    #             target = :D, custom_NN = true, loss = LossV())
+    #     end
+    # end
 
     if GROUP == "All" || GROUP == "Core8"
         @testset "Multi-objective function and regularization test" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,8 +207,9 @@ ENV["GKSwstype"] = "nul"
         @testset "Adjoint method of SIA equation with pure D as target and custom NN" begin
             # @testset "Manual implementation of the continuous adjoint with discrete VJP and custom NN vs finite differences" test_grad_finite_diff(ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [1e-3, 1e-7, 1e-3], target = :D, custom_NN = true)
             @testset "Manual implementation of the continuous adjoint with discrete VJP and custom NN vs finite differences (loss V)" test_grad_finite_diff(
-                ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [5e-3, 1e-7, 5e-3],
-                target = :D, custom_NN = true, loss = LossV())
+                ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [1e-4, 1e-7, 1e-4],
+                target = :D, custom_NN = true, loss = LossV(),
+                max_params = 25, mask_parameter_vector = true)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -202,16 +202,15 @@ ENV["GKSwstype"] = "nul"
                 thres = [5e-3, 1e-6, 5e-3], target = :D, loss = LossV())
         end
     end
-    # Skip this test because it consumes too much memory which leads to Jula being killed in the CI
-    # if (GROUP == "All" && (!CI || !Sys.isapple())) || GROUP == "Core7"
-    #     # Skip this test on macOS when running the "Full tests" CI because it is too slow and produces a timeout error (>6h)
-    #     @testset "Adjoint method of SIA equation with pure D as target and custom NN" begin
-    #         # @testset "Manual implementation of the continuous adjoint with discrete VJP and custom NN vs finite differences" test_grad_finite_diff(ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [1e-3, 1e-7, 1e-3], target = :D, custom_NN = true)
-    #         @testset "Manual implementation of the continuous adjoint with discrete VJP and custom NN vs finite differences (loss V)" test_grad_finite_diff(
-    #             ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [5e-3, 1e-7, 5e-3],
-    #             target = :D, custom_NN = true, loss = LossV())
-    #     end
-    # end
+    if (GROUP == "All" && (!CI || !Sys.isapple())) || GROUP == "Core7"
+        # Skip this test on macOS when running the "Full tests" CI because it is too slow and produces a timeout error (>6h)
+        @testset "Adjoint method of SIA equation with pure D as target and custom NN" begin
+            # @testset "Manual implementation of the continuous adjoint with discrete VJP and custom NN vs finite differences" test_grad_finite_diff(ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [1e-3, 1e-7, 1e-3], target = :D, custom_NN = true)
+            @testset "Manual implementation of the continuous adjoint with discrete VJP and custom NN vs finite differences (loss V)" test_grad_finite_diff(
+                ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [5e-3, 1e-7, 5e-3],
+                target = :D, custom_NN = true, loss = LossV())
+        end
+    end
 
     if GROUP == "All" || GROUP == "Core8"
         @testset "Multi-objective function and regularization test" begin

--- a/test/test_grad_loss.jl
+++ b/test/test_grad_loss.jl
@@ -327,7 +327,7 @@ function test_grad_finite_diff(
                     end
                 else
                     # Mask parameter vector
-                    if mask_parameter_vector && (length(θ[key]) < max_params)
+                    if mask_parameter_vector && (length(θ[key]) > max_params)
                         indx = ODINN.sample(1:length(θ[key]), max_params; replace = false)
                     else
                         indx = 1:length(θ[key]) |> collect

--- a/test/test_grad_loss.jl
+++ b/test/test_grad_loss.jl
@@ -116,7 +116,7 @@ function test_grad_finite_diff(
             workers = 1,
             test_mode = true,
             rgi_paths = rgi_paths,
-            gridScalingFactor = 4,
+            gridScalingFactor = custom_NN ? 8 : 4,
             f_surface_velocity_factor = 0.8
         ),
         hyper = Hyperparameters(
@@ -690,7 +690,7 @@ function test_grad_sciml_vs_manual(; thres = [1e-3, 1e-13, 1e-3])
             workers = 1,
             test_mode = true,
             rgi_paths = rgi_paths,
-            gridScalingFactor = custom_NN ? 8 : 4,
+            gridScalingFactor = 4,
             f_surface_velocity_factor = 0.8
         ),
         hyper = Hyperparameters(batch_size = 1, epochs = 100, optimizer = ODINN.Adam(0.005)),

--- a/test/test_grad_loss.jl
+++ b/test/test_grad_loss.jl
@@ -38,7 +38,7 @@ method and finite-difference schemes, and compares them using diagnostic metrics
   - `multiglacier::Bool`: Whether to run the test on multiple glaciers.
   - `use_MB::Bool`: Whether to include a mass balance model (MB) during training/testing.
   - `functional_inv::Bool`: Whether to test functional inversions or classical inversions.
-  - `custom_NN::Bool`: Whether to use a custom-defined neural network architecture for testing or a simple default small network.
+  - `custom_NN::Bool`: Whether to use a custom-defined neural network architecture for testing or a simple default small network. If the custom neural network is used, the glacier grid and the number of points in the VJP interpolation are reduced to spare computation time and memory.
   - `max_params::Int`: Maximum number of parameters for finite-difference testing; if exceeded, a random subset is tested to reduce computational cost.
   - `mask_parameter_vector::Bool`: Whether to apply a mask to the parameter vector `θ` before evaluating finite-difference gradients. If `false`, the
     mask based on `max_params` is just applied to the initial conditions, not to parameters of the regressor.
@@ -244,7 +244,7 @@ function test_grad_finite_diff(
             regressors = regressors,
             target = SIA2D_D_target(
                 interpolation = :Linear,
-                n_interp_half = 200
+                n_interp_half = custom_NN ? 50 : 200
             )
         )
     end
@@ -690,7 +690,7 @@ function test_grad_sciml_vs_manual(; thres = [1e-3, 1e-13, 1e-3])
             workers = 1,
             test_mode = true,
             rgi_paths = rgi_paths,
-            gridScalingFactor = 4,
+            gridScalingFactor = custom_NN ? 8 : 4,
             f_surface_velocity_factor = 0.8
         ),
         hyper = Hyperparameters(batch_size = 1, epochs = 100, optimizer = ODINN.Adam(0.005)),


### PR DESCRIPTION
@facusapienza21 with recent versions of the packages we are using, the custom NN with pure diffusivity test no longer passes within the CI. This is because of an out of memory error. Don't you mind if I deactivate that test?