### PR TITLE
Remove parametric type for initial_conditions in TrainingStats

### DIFF
--- a/src/inverse/SIA2D/gradient.jl
+++ b/src/inverse/SIA2D/gradient.jl
@@ -102,7 +102,7 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
             tstopsDiscreteLoss, tstopsAggregatedLoss)))
 
         @assert length(t) == length(tstops) "The size of tstops does not match with the size of the reference times."
-        @assert isapprox(t, tstops, rtol = 1e-10) "Times in tstops and reference times in result do not coincide. Maximum difference is $(maximum(abs.(t-tstops)))"
+        @assert isapprox(t, tstops, rtol = 1e-7) "Times in tstops and reference times in result do not coincide. Maximum difference is $(maximum(abs.(t-tstops)))"
         if useThickness
             @assert size(H[begin]) == size(H_ref[begin])
         end
@@ -366,7 +366,6 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
                 stop_condition_loss, integrator -> effect_loss!(-integrator.t, integrator.u))
 
             # Contribution of aggregated losses
-            # @infiltrate
             ∂L∂H_aggregated_loss,
             ∂L∂θ_aggregated_loss = if length(tstopsAggregatedLoss)>0
                 indPostIntegralLoss = Sleipnir.indFromT(tspan, tstopsAggregatedLoss, t)

--- a/src/inverse/SIA2D/gradient.jl
+++ b/src/inverse/SIA2D/gradient.jl
@@ -102,7 +102,7 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
             tstopsDiscreteLoss, tstopsAggregatedLoss)))
 
         @assert length(t) == length(tstops) "The size of tstops does not match with the size of the reference times."
-        @assert isapprox(t, tstops, rtol = 1e-7) "Times in tstops and reference times in result do not coincide. Maximum difference is $(maximum(abs.(t-tstops)))"
+        @assert isapprox(t, tstops, rtol = 1e-10) "Times in tstops and reference times in result do not coincide. Maximum difference is $(maximum(abs.(t-tstops)))"
         if useThickness
             @assert size(H[begin]) == size(H_ref[begin])
         end
@@ -366,6 +366,7 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
                 stop_condition_loss, integrator -> effect_loss!(-integrator.t, integrator.u))
 
             # Contribution of aggregated losses
+            # @infiltrate
             ∂L∂H_aggregated_loss,
             ∂L∂θ_aggregated_loss = if length(tstopsAggregatedLoss)>0
                 indPostIntegralLoss = Sleipnir.indFromT(tspan, tstopsAggregatedLoss, t)

--- a/src/simulations/results/Results.jl
+++ b/src/simulations/results/Results.jl
@@ -5,8 +5,7 @@ export TrainingStats, Results
         F <: AbstractFloat,
         I <: Integer,
         RETC <: Union{String, Nothing},
-        THETA_HIST <: ComponentVector,
-        IC <: Union{Dict, Nothing}
+        THETA_HIST <: ComponentVector
     }
 
 An object with the information of the training.
@@ -19,7 +18,7 @@ An object with the information of the training.
   - `θ::Union{<: ComponentVector, Nothing}`: Parameters of neural network after training.
   - `θ_hist::Vector{THETA_HIST}`: History of parameters of neural network during training.
   - `∇θ_hist::Vector{THETA_HIST}`: History of gradients training.
-  - `initial_conditions::IC`: Initial conditions used to solve the PDEs.
+  - `initial_conditions::Union{<: Dict, Nothing}`: Initial conditions used to solve the PDEs.
   - `lastCall::DateTime`: Last time the callback diagnosis was called.
     This is used to compute the time per iteration.
 """
@@ -27,8 +26,7 @@ mutable struct TrainingStats{
     F <: AbstractFloat,
     I <: Integer,
     RETC <: Union{String, Nothing},
-    THETA_HIST <: ComponentVector,
-    IC <: Union{Dict, Nothing}
+    THETA_HIST <: ComponentVector
 }
     retcode::RETC
     losses::Vector{F}
@@ -36,7 +34,7 @@ mutable struct TrainingStats{
     θ::Union{<: ComponentVector, Nothing}
     θ_hist::Vector{THETA_HIST}
     ∇θ_hist::Vector{THETA_HIST}
-    initial_conditions::IC
+    initial_conditions::Union{<: Dict, Nothing}
     lastCall::DateTime
 end
 
@@ -77,7 +75,7 @@ function TrainingStats(;
     @assert length(θ_hist) == niter
 
     training_stats = TrainingStats{eltype(losses), typeof(niter), typeof(retcode),
-        eltype(θ_hist), typeof(initial_conditions)}(
+        eltype(θ_hist)}(
         retcode, losses, niter, θ, θ_hist, ∇θ_hist, initial_conditions, DateTime(0, 1, 1)
     )
 


### PR DESCRIPTION
- Remove parametric type for `initial_conditions` in `TrainingStats` as we need flexibility to change the type at runtime

Fixes #517 