### PR TITLE
Fix cache dimensions bug

### DIFF
--- a/scripts/MWEs/inversion_A/inversion_setup.jl
+++ b/scripts/MWEs/inversion_A/inversion_setup.jl
@@ -62,7 +62,7 @@ params = Parameters(
         grad = ContinuousAdjoint(),
         optimization_method = "AD+AD",
         empirical_loss_function = MultiLoss(
-            losses = (LossH(), InitialThicknessRegularization(t₀ = 1994.0)),
+            losses = (LossH(), InitialThicknessRegularization(1994.0)),
             λs = (1.0, 1e-4)
         ),
         target = :A,

--- a/scripts/MWEs/inversion_A/inversion_setup.jl
+++ b/scripts/MWEs/inversion_A/inversion_setup.jl
@@ -62,7 +62,7 @@ params = Parameters(
         grad = ContinuousAdjoint(),
         optimization_method = "AD+AD",
         empirical_loss_function = MultiLoss(
-            losses = (LossH(), InitialThicknessRegularization()),
+            losses = (LossH(), InitialThicknessRegularization(t₀ = 1994.0)),
             λs = (1.0, 1e-4)
         ),
         target = :A,

--- a/src/inverse/SIA2D/adjoint.jl
+++ b/src/inverse/SIA2D/adjoint.jl
@@ -250,7 +250,7 @@ function VJP_λ_∂SIA∂θ_discrete(
     @tullio ∂θ_v[k] := ∂D∂θ[i, j, k] * D_adjoint[i, j]
     # Construct component vector
     ∂θ = zero(θ)
-    ∂θ.A .= vec(∂θ_v)
+    assign_∂θ!(target, ∂θ, ∂θ_v)
 
     return ∂θ
 end
@@ -409,7 +409,7 @@ function VJP_λ_∂surface_V∂θ_discrete(
     @tullio ∂θ_v[k] := ∂D∂θ[i, j, k] * ∇S∂V[i, j]
     # Construct component vector
     ∂θ = zero(θ)
-    ∂θ.A .= vec(∂θ_v)
+    assign_∂θ!(target, ∂θ, ∂θ_v)
 
     return -∂θ
 end
@@ -659,7 +659,7 @@ function VJP_λ_∂SIA∂θ_continuous(
     @tullio ∂θ_v[k] := ∇_∂D∂θ_∇S[i, j, k] * λ[i, j]
 
     ∂θ = zero(θ)
-    ∂θ.A .= vec(∂θ_v)
+    assign_∂θ!(target, ∂θ, ∂θ_v)
 
     return ∂θ
 end

--- a/src/inverse/SIA2D/adjoint.jl
+++ b/src/inverse/SIA2D/adjoint.jl
@@ -249,7 +249,8 @@ function VJP_λ_∂SIA∂θ_discrete(
     # Evaluate numerical integral for loss
     @tullio ∂θ_v[k] := ∂D∂θ[i, j, k] * D_adjoint[i, j]
     # Construct component vector
-    ∂θ = Vector2ComponentVector(∂θ_v, θ)
+    ∂θ = zero(θ)
+    ∂θ.A .= vec(∂θ_v)
 
     return ∂θ
 end
@@ -407,7 +408,8 @@ function VJP_λ_∂surface_V∂θ_discrete(
     # Evaluate numerical integral for loss
     @tullio ∂θ_v[k] := ∂D∂θ[i, j, k] * ∇S∂V[i, j]
     # Construct component vector
-    ∂θ = Vector2ComponentVector(∂θ_v, θ)
+    ∂θ = zero(θ)
+    ∂θ.A .= vec(∂θ_v)
 
     return -∂θ
 end
@@ -656,7 +658,8 @@ function VJP_λ_∂SIA∂θ_continuous(
     # Evaluate numerical integral for loss
     @tullio ∂θ_v[k] := ∇_∂D∂θ_∇S[i, j, k] * λ[i, j]
 
-    ∂θ = Vector2ComponentVector(∂θ_v, θ)
+    ∂θ = zero(θ)
+    ∂θ.A .= vec(∂θ_v)
 
     return ∂θ
 end

--- a/src/laws/Laws.jl
+++ b/src/laws/Laws.jl
@@ -452,7 +452,8 @@ function LawA(params::Sleipnir.Parameters; scalar::Bool = true)
 
         init_cache = function (simulation, glacier_idx, θ)
             (; nx, ny) = simulation.glaciers[glacier_idx]
-            MatrixCacheGlacierId(zeros(nx-1, ny-1), zeros(nx-1, ny-1), vec(zero(θ.A[Symbol("$(glacier_idx)")])), glacier_idx)
+            MatrixCacheGlacierId(zeros(nx-1, ny-1), zeros(nx-1, ny-1),
+                vec(zero(θ.A[Symbol("$(glacier_idx)")])), glacier_idx)
         end
 
         p_VJP! = function (cache, vjpsPrepLaw, inputs, θ)

--- a/src/laws/Laws.jl
+++ b/src/laws/Laws.jl
@@ -147,7 +147,7 @@ function LawU(
     init_cache_matrix = function (simulation, glacier_idx, θ)
         glacier = simulation.glaciers[glacier_idx]
         (; nx, ny) = glacier
-        return MatrixCache(zeros(nx - 1, ny - 1), zeros(nx - 1, ny - 1), zero(θ))
+        return MatrixCache(zeros(nx - 1, ny - 1), zeros(nx - 1, ny - 1), zero(θ.U))
     end
 
     p_VJP! = let smodel = smodel, prescale = prescale, postscale = postscale
@@ -162,7 +162,7 @@ function LawU(
                 grad, = Zygote.gradient(
                     _θ -> _pred_NN(
                         [h, ∇s], smodel, _θ.U, prescale, postscale), θ)
-                grads[i, j] .= ODINN.ComponentVector2Vector(grad)
+                grads[i, j] .= ODINN.ComponentVector2Vector(grad.U)
             end
             cache.interp_θ = interpolate((nodes_H, nodes_∇S), grads, Gridded(Linear()))
         end
@@ -265,7 +265,7 @@ function LawY(
             end,
             init_cache = function (simulation, glacier_idx, θ; scalar::Bool = true)
                 (; nx, ny) = simulation.glaciers[glacier_idx]
-                return MatrixCache(zeros(nx-1, ny-1), zeros(nx-1, ny-1), zero(θ))
+                return MatrixCache(zeros(nx-1, ny-1), zeros(nx-1, ny-1), zero(θ.Y))
             end
         )
     end
@@ -358,7 +358,7 @@ function LawA(
     end
     p_VJP! = function (cache, vjpsPrepLaw, inputs, θ)
         ret, = Zygote.gradient(_θ -> f!(cache, inputs, _θ), θ)
-        cache.vjp_θ .= ret
+        cache.vjp_θ .= ret.A
     end
     A_law = if scalar
         Law{ScalarCache}(;
@@ -366,7 +366,7 @@ function LawA(
             inputs = input,
             f! = f!,
             init_cache = function (simulation, glacier_idx, θ)
-                return ScalarCache(zeros(), zeros(), zero(θ))
+                return ScalarCache(zeros(), zeros(), zero(θ.A))
             end,
             p_VJP! = precompute_VJPs ? p_VJP! : nothing,
             callback_freq = callback_freq
@@ -378,7 +378,7 @@ function LawA(
             f! = f!,
             init_cache = function (simulation, glacier_idx, θ)
                 (; nx, ny) = simulation.glaciers[glacier_idx]
-                return MatrixCache(zeros(nx, ny), zeros(nx, ny), zero(θ))
+                return MatrixCache(zeros(nx, ny), zeros(nx, ny), zero(θ.A))
             end
         )
     end

--- a/src/laws/Laws.jl
+++ b/src/laws/Laws.jl
@@ -424,7 +424,7 @@ function LawA(params::Sleipnir.Parameters; scalar::Bool = true)
             end
         end
         init_cache = function (simulation, glacier_idx, θ)
-            ScalarCacheGlacierId(zeros(), zeros(), zero(θ), glacier_idx)
+            ScalarCacheGlacierId(zeros(), zeros(), vec(zero(θ.A[Symbol("$(glacier_idx)")])), glacier_idx)
         end
 
         p_VJP! = function (cache, vjpsPrepLaw, inputs, θ)
@@ -516,7 +516,7 @@ function LawC(params::Sleipnir.Parameters; scalar::Bool = true)
 
     if scalar
         init_cache = function (simulation, glacier_idx, θ)
-            ScalarCacheGlacierId(zeros(), zeros(), zero(θ), glacier_idx)
+            ScalarCacheGlacierId(zeros(), zeros(), vec(zero(θ.C[Symbol("$(glacier_idx)")])), glacier_idx)
         end
 
         C_law = Law{ScalarCacheGlacierId}(;
@@ -528,7 +528,8 @@ function LawC(params::Sleipnir.Parameters; scalar::Bool = true)
     else
         init_cache = function (simulation, glacier_idx, θ)
             (; nx, ny) = simulation.glaciers[glacier_idx]
-            MatrixCacheGlacierId(zeros(nx-1, ny-1), zeros(nx-1, ny-1), zero(θ), glacier_idx)
+            MatrixCacheGlacierId(zeros(nx-1, ny-1), zeros(nx-1, ny-1),
+                vec(zero(θ.C[Symbol("$(glacier_idx)")])), glacier_idx)
         end
 
         C_law = Law{MatrixCacheGlacierId}(;

--- a/src/laws/Laws.jl
+++ b/src/laws/Laws.jl
@@ -452,13 +452,15 @@ function LawA(params::Sleipnir.Parameters; scalar::Bool = true)
 
         init_cache = function (simulation, glacier_idx, θ)
             (; nx, ny) = simulation.glaciers[glacier_idx]
-            MatrixCacheGlacierId(zeros(nx-1, ny-1), zeros(nx-1, ny-1), zero(θ), glacier_idx)
+            #@infiltrate
+            MatrixCacheGlacierId(zeros(nx-1, ny-1), zeros(nx-1, ny-1), vec(zero(θ.A[Symbol("$(glacier_idx)")])), glacier_idx)
         end
 
         p_VJP! = function (cache, vjpsPrepLaw, inputs, θ)
             # In this function we compute the diagonal of the Jacobian since `f!` applies element-wise
             # We do so by using the `sum` trick below
             ret, = Zygote.gradient(_θ -> sum(f!(cache, inputs, _θ)), θ)
+            #@infiltrate
             cache.vjp_θ .= vec(ret.A[Symbol("$(cache.glacier_id)")])
         end
 

--- a/src/laws/Laws.jl
+++ b/src/laws/Laws.jl
@@ -452,7 +452,6 @@ function LawA(params::Sleipnir.Parameters; scalar::Bool = true)
 
         init_cache = function (simulation, glacier_idx, θ)
             (; nx, ny) = simulation.glaciers[glacier_idx]
-            #@infiltrate
             MatrixCacheGlacierId(zeros(nx-1, ny-1), zeros(nx-1, ny-1), vec(zero(θ.A[Symbol("$(glacier_idx)")])), glacier_idx)
         end
 
@@ -460,7 +459,6 @@ function LawA(params::Sleipnir.Parameters; scalar::Bool = true)
             # In this function we compute the diagonal of the Jacobian since `f!` applies element-wise
             # We do so by using the `sum` trick below
             ret, = Zygote.gradient(_θ -> sum(f!(cache, inputs, _θ)), θ)
-            #@infiltrate
             cache.vjp_θ .= vec(ret.A[Symbol("$(cache.glacier_id)")])
         end
 

--- a/src/losses/Regularization.jl
+++ b/src/losses/Regularization.jl
@@ -45,7 +45,7 @@ struct TikhonovRegularization{I <: Integer} <: AbstractSimpleRegularization
 end
 
 """
-    InitialThicknessRegularization(; reg = TikhonovRegularization(), t₀ = 1994.0)
+    InitialThicknessRegularization(t₀::AbstractFloat; reg::AbstractSimpleRegularization = TikhonovRegularization())
 
 A composite regularization type designed for initial ice thickness.
 It combines a simple spatial regularization (e.g., `TikhonovRegularization`) with a reference initial time.
@@ -55,10 +55,15 @@ It combines a simple spatial regularization (e.g., `TikhonovRegularization`) wit
   - `reg::AbstractSimpleRegularization = TikhonovRegularization()`: The spatial regularization operator applied to the initial field. By default, a Tikhonov (Laplacian-based) regularization is used.
   - `t₀::AbstractFloat = 1994.0`: The reference initial time (e.g., year) at which the regularization applies.
 """
-@kwdef struct InitialThicknessRegularization{
+struct InitialThicknessRegularization{
     R <: AbstractSimpleRegularization, F <: AbstractFloat} <: AbstractRegularization
-    reg::R = TikhonovRegularization()
-    t₀::F = 1994.0
+    reg::R
+    t₀::F
+
+    function InitialThicknessRegularization(
+            t₀::AbstractFloat; reg::AbstractSimpleRegularization = TikhonovRegularization())
+        return new{typeof(reg), typeof(t₀)}(reg, t₀)
+    end
 end
 
 """

--- a/src/models/target/target_A.jl
+++ b/src/models/target/target_A.jl
@@ -168,3 +168,7 @@ function ∂Velocityꜛ∂θ(
         return sparse_cartesian_tensor(∂A_spatial, iceflow_cache.A.vjp_θ)
     end
 end
+
+function assign_∂θ!(target::SIA2D_A_target, ∂θ, ∂θ_v)
+    ∂θ.A .= vec(∂θ_v)
+end

--- a/src/models/target/target_D_hybrid.jl
+++ b/src/models/target/target_D_hybrid.jl
@@ -370,3 +370,7 @@ function compute_Velocityꜛ(
     )
     return D
 end
+
+function assign_∂θ!(target::SIA2D_D_hybrid_target, ∂θ, ∂θ_v)
+    ∂θ.Y .= vec(∂θ_v)
+end

--- a/src/models/target/target_D_pure.jl
+++ b/src/models/target/target_D_pure.jl
@@ -251,3 +251,7 @@ function ∂Velocityꜛ∂θ(
     ∂D∂θꜛ = ∂U∂θ(target; H̄, ∇S, θ, simulation, glacier_idx, t, glacier, params) / f
     return ∂D∂θꜛ
 end
+
+function assign_∂θ!(target::SIA2D_D_target, ∂θ, ∂θ_v)
+    ∂θ.U .= vec(∂θ_v)
+end

--- a/src/models/trainable_components/ML_utils.jl
+++ b/src/models/trainable_components/ML_utils.jl
@@ -93,7 +93,7 @@ function build_simulation_batch(
     # but we need to pay attention that there is no side effect with multiprocessing
     model = Sleipnir.Model(iceflow, massbalance, submodels)
 
-    cache = init_cache(model, simulation, i, θi)
+    cache = init_cache(model, simulation, 1, θi) # We set glacier_idx=1 because the elements of θ which are subject to classical inversion have been split into θi
     glacier = simulation.glaciers[i]
     if length(simulation.results.simulation) < 1
         return Inversion{

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -247,7 +247,7 @@ ENV["GKSwstype"] = "nul"
                 ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [1e-4, 1e-8, 1e-4],
                 functional_inv = false, scalar = false,
                 loss = MultiLoss(
-                    losses = (LossH(), InitialThicknessRegularization(t₀ = 2010.0)), λs = (
+                    losses = (LossH(), InitialThicknessRegularization(2010.0)), λs = (
                         1.0, 1.0)),
                 train_initial_conditions = true)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -242,6 +242,15 @@ ENV["GKSwstype"] = "nul"
                     functional_inv = false, scalar = true, loss = LossAvgV(), aggregated_loss = :avgV)
             end
         end
+        @testset "Joint inversion" begin
+            @testset "Gridded A + IC" test_grad_finite_diff(
+                ContinuousAdjoint(VJP_method = DiscreteVJP()); thres = [1e-4, 1e-8, 1e-4],
+                functional_inv = false, scalar = false,
+                loss = MultiLoss(
+                    losses = (LossH(), InitialThicknessRegularization(t₀ = 2010.0)), λs = (
+                        1.0, 1.0)),
+                train_initial_conditions = true)
+        end
     end
 
     if GROUP == "All" || GROUP == "Core9"


### PR DESCRIPTION
- Fix cache dimension bug for joint inversions #516 
- Make `t₀` mandatory when declaring `InitialThicknessRegularization`. The default value used to be 1994.0 and when `t₀` was outside of `tspan`, this led to obscure errors. Since we have no way to check the value of `t₀` in `InitialThicknessRegularization`, we cannot add an assert. The user now has to provide an explicit value.
- Add a joint inversion test (gridded A + IC)