### PR TITLE
Use var-specific bounds in GlacierWideInv

### DIFF
--- a/src/models/trainable_components/GlacierWideInv.jl
+++ b/src/models/trainable_components/GlacierWideInv.jl
@@ -17,19 +17,24 @@ Per glacier invertible parameter container.
     GlacierWideInv(
         params::Sleipnir.Parameters,
         glaciers::Vector{<: AbstractGlacier},
-        var::Symbol,
+        var::Symbol;
+        minval::Union{Nothing, Float64} = nothing,
+        maxval::Union{Nothing, Float64} = nothing,
     )
 
 # Arguments
 
   - `params::Sleipnir.Parameters`: Parameters struct.
   - `glaciers::Vector{<: AbstractGlacier}`: Vector of AbstractGlacier. The i-th entry in θ corresponds to glaciers[i].
-  - `var::Symbol`: Symbol naming the field on each glacier to use as the initial value.
+  - `var::Symbol`: Symbol naming the field on each glacier to use as the initial value. Only `:A` and `:C` are supported.
+  - `minval::Union{Nothing, Float64}`: Lower bound of the parameterization. Defaults to `params.physical.minA` for `:A`; unused for `:C`, whose lower bound is always zero.
+  - `maxval::Union{Nothing, Float64}`: Upper bound of the parameterization. Defaults to `params.physical.maxA` for `:A` and `params.physical.maxC` for `:C`.
 
 # Example
 
 ```julia
 GlacierWideInv(params, glaciers, :A)
+GlacierWideInv(params, glaciers, :C)
 ```
 """
 mutable struct GlacierWideInv{
@@ -40,18 +45,28 @@ mutable struct GlacierWideInv{
     function GlacierWideInv(
             params::Sleipnir.Parameters,
             glaciers::Vector{<: AbstractGlacier},
-            var::Symbol
+            var::Symbol;
+            minval::Union{Nothing, Float64} = nothing,
+            maxval::Union{Nothing, Float64} = nothing
     )
-        inv_param_type = Tuple(Symbol("$(i)") for i in 1:length(glaciers))
-        inv_param = NamedTuple{inv_param_type}(
-            Tuple(fill(getfield(glaciers[i], var)) for i in 1:length(glaciers))
-        )
-        θ = ComponentVector{Sleipnir.Float}(θ = inv_param)
+        # Inverse of the tanh parameterization used by the corresponding law, so that θ₀
+        # maps back to the glacier's initial value. LawA spans [minA, maxA], LawC [0, maxC].
+        unparameterize = if var == :A
+            minv = isnothing(minval) ? params.physical.minA : minval
+            maxv = isnothing(maxval) ? params.physical.maxA : maxval
+            v -> atanh(2 * (v - minv) / (maxv - minv) - 1)
+        elseif var == :C
+            maxv = isnothing(maxval) ? params.physical.maxC : maxval
+            # C = 0 (no sliding) would give atanh(-1) = -Inf, so seed it just inside the bound
+            v -> 0 < v < maxv ? atanh(2 * v / maxv - 1) : Sleipnir.Float(-5)
+        else
+            error("GlacierWideInv: only :A and :C are supported for var (got $(var))")
+        end
 
-        # Invert parameterization
-        minA = params.physical.minA
-        maxA = params.physical.maxA
-        θ = atanh.((θ .- minA) .* (2/(maxA-minA)) .- 1.0)
+        glacier_keys = Tuple(Symbol("$(i)") for i in 1:length(glaciers))
+        θ₀ = Tuple(
+            fill(unparameterize(Sleipnir.Float(getfield(g, var)))) for g in glaciers)
+        θ = ComponentVector{Sleipnir.Float}(θ = NamedTuple{glacier_keys}(θ₀))
 
         new{typeof(θ)}(θ)
     end

--- a/test/inversion_test.jl
+++ b/test/inversion_test.jl
@@ -271,3 +271,43 @@ function inversion_test(;
         @test minimum(rel_error) < 1e-4
     end
 end
+
+"""
+    test_C_parameterization()
+
+Check that the θ₀ built for `:C` inverts the tanh parameterization applied by `LawC`.
+`maxC` is set well apart from the A bounds so that applying the A bounds to C is caught.
+The `:A` round-trip is already covered by the scalar and gridded inversion tests above.
+"""
+function test_C_parameterization()
+    maxC = 1e-15
+    C = 3e-16
+    params = Parameters(
+        simulation = SimulationParameters(
+            tspan = (2010.0, 2012.0), multiprocessing = false,
+            use_MB = false, test_mode = true, working_dir = Huginn.root_dir),
+        physical = PhysicalParameters(minA = 8e-21, maxA = 8e-18, maxC = maxC)
+    )
+
+    nx, ny = 5, 5
+    toy_glacier(C) = Glacier2D(
+        rgi_id = "toy", H₀ = ones(nx, ny), S = ones(nx, ny), B = zeros(nx, ny),
+        A = 5e-19, C = C, n = 3.0, Δx = 50.0, Δy = 50.0, nx = nx, ny = ny)
+
+    forwardC(θ) = maxC * (tanh(θ) + 1) / 2 # The map applied by LawC
+    glaciers = Vector{Sleipnir.AbstractGlacier}([toy_glacier(C)])
+
+    @test all(forwardC.(GlacierWideInv(params, glaciers, :C).θ.θ[Symbol("1")]) .≈ C)
+    @test all(forwardC.(GriddedInv(params, glaciers, :C).θ.θ[Symbol("1")]) .≈ C)
+
+    # C = 0 is the Glacier2D default and has no finite preimage, so it must be seeded
+    # rather than sent to atanh(-1) = -Inf
+    zero_C = Vector{Sleipnir.AbstractGlacier}([toy_glacier(0.0)])
+    for θ in (GlacierWideInv(params, zero_C, :C).θ, GriddedInv(params, zero_C, :C).θ)
+        @test all(isfinite, θ.θ[Symbol("1")])
+        @test all(forwardC.(θ.θ[Symbol("1")]) .< 1e-3 * maxC)
+    end
+
+    @test_throws ErrorException GlacierWideInv(params, glaciers, :n)
+    @test_throws ErrorException GriddedInv(params, glaciers, :n)
+end

--- a/test/inversion_test.jl
+++ b/test/inversion_test.jl
@@ -305,7 +305,7 @@ function test_C_parameterization()
     zero_C = Vector{Sleipnir.AbstractGlacier}([toy_glacier(0.0)])
     for θ in (GlacierWideInv(params, zero_C, :C).θ, GriddedInv(params, zero_C, :C).θ)
         @test all(isfinite, θ.θ[Symbol("1")])
-        @test all(forwardC.(θ.θ[Symbol("1")]) .< 1e-3 * maxC)
+        @test all(forwardC.(θ.θ[Symbol("1")]) .<= forwardC(Sleipnir.Float(-5))
     end
 
     @test_throws ErrorException GlacierWideInv(params, glaciers, :n)

--- a/test/inversion_test.jl
+++ b/test/inversion_test.jl
@@ -305,7 +305,7 @@ function test_C_parameterization()
     zero_C = Vector{Sleipnir.AbstractGlacier}([toy_glacier(0.0)])
     for θ in (GlacierWideInv(params, zero_C, :C).θ, GriddedInv(params, zero_C, :C).θ)
         @test all(isfinite, θ.θ[Symbol("1")])
-        @test all(forwardC.(θ.θ[Symbol("1")]) .<= forwardC(Sleipnir.Float(-5))
+        @test all(forwardC.(θ.θ[Symbol("1")]) .<= forwardC(Sleipnir.Float(-5)))
     end
 
     @test_throws ErrorException GlacierWideInv(params, glaciers, :n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,7 @@ ENV["GKSwstype"] = "nul"
         @testset "Training workflow without sensitivity analysis and AD (with MB)" grad_free_test(use_MB = true)
         @testset "Parameters constructors with specified values" params_constructor_specified()
         @testset "Inversion instantiation" test_inversion_instantiation()
+        @testset "C parameterization of inversion containers" test_C_parameterization()
 
         @testset "Adjoint of unit operations inside SIA2D" begin
             @testset "Adjoint of diff" test_adjoint_diff()


### PR DESCRIPTION
`GlacierWideInv` applied the `minA`/`maxA` atanh re-parameterization regardless of which variable was passed as `var`, so `GlacierWideInv(params, glaciers, :C)` built a θ₀ scaled by the A bounds. This turned out to be worse than a scaling error: `Glacier2D.C` defaults to 0, so the constructor evaluated `atanh(2*(0 - minA)/(maxA - minA) - 1)` and threw a `DomainError`.

Worth flagging one subtlety, since the issue suggested looking up `min{var}`/`max{var}` from `PhysicalParameters`: that would still be wrong for C. `LawC` applies `C = maxC * (tanh(θ) + 1) / 2`, whose lower bound is 0, not `minC`. The θ₀ has to invert the map the law actually applies, so the bounds pair for `:C` is `[0, maxC]` and `minC` stays unused here. `GriddedInv` had already worked this out, so this mirrors it rather than introducing a second convention — the two containers feed the same laws and must agree.

`C = 0` has no finite preimage and is now seeded just inside the bound. Unsupported variables error instead of silently producing nonsense, matching `GriddedInv`. `minval`/`maxval` overrides are available for callers who want non-default bounds.

Note this is currently masked by Sleipnir's defaults, where `maxA == maxC == 8e-17` — it only bites once a realistic `maxC` is set, which is still an open TODO there.

@girodlis this should unblock the C gridded inversions.

## Testing

Adds `test_C_parameterization()`, which had no equivalent before — `LawC` appears nowhere in the suite, and the existing "C>0" adjoint tests only assign `glacier.C` as a constant, never going through the inversion containers. It checks that `:C` round-trips through `LawC`'s forward map for both containers, that `C = 0` stays finite, and that unsupported vars error. No downloads and no PDE solve; runs in 3.9 s.

Verified it fails against the old code, where the first assertion feeds `atanh(74.07)`.

Fixes #514