### PR TITLE
Switch docs build from main to dev

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches:
-      - main # update to match your development branch (master, main, dev, trunk, ...)
+      - dev # update to match your development branch (master, main, dev, trunk, ...)
     tags: '*'
     paths-ignore:
       - 'test/**'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,8 @@ name: Documentation
 on:
   push:
     branches:
-      - dev # update to match your development branch (master, main, dev, trunk, ...)
+      - dev
+      - main
     tags: '*'
     paths-ignore:
       - 'test/**'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -134,10 +134,14 @@ makedocs(
 )
 
 if get(ENV, "CI", nothing)=="true"
+    # `dev` and `main` are deployed by independent CI triggers, each into its own folder
+    deployed_branch = get(ENV, "GITHUB_REF_NAME", "") == "main" ? "main" : "dev"
     deploydocs(
         repo = "github.com/ODINN-SciML/ODINN.jl",
         branch = "gh-pages",
-        devbranch = "dev",
+        devbranch = deployed_branch,
+        devurl = deployed_branch,
+        versions = ["dev" => "dev", "main" => "main"],
         push_preview = true,
         forcepush = true
     )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -137,7 +137,7 @@ if get(ENV, "CI", nothing)=="true"
     deploydocs(
         repo = "github.com/ODINN-SciML/ODINN.jl",
         branch = "gh-pages",
-        devbranch = "main",
+        devbranch = "dev",
         push_preview = true,
         forcepush = true
     )


### PR DESCRIPTION
Make `dev` the default to build the docs, this way we can easily integrate the latest changes directly into the documentation. 