### PR TITLE
Differentiate mass balance in the RHS, delete the jump adjoint

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,6 +75,7 @@ jobs:
           - Core9
           - Core10
           - Core11
+          - Core12
           - Aqua
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI_fast.yml
+++ b/.github/workflows/CI_fast.yml
@@ -74,6 +74,7 @@ jobs:
           - Core9
           - Core10
           - Core11
+          - Core12
           - Aqua
     steps:
       - uses: actions/checkout@v4

--- a/docs/src/extending.md
+++ b/docs/src/extending.md
@@ -134,9 +134,9 @@ New mass balance models subtype `MBmodel` (defined in `Muninn`). Mass balance is
 \frac{\partial H}{\partial t} = -\nabla\cdot(D\nabla S) + \dot m(H, t)
 ```
 
-so a model supplies a **rate**, evaluated at every step of the solve, rather than an increment applied by a callback. There is no mass balance callback: that is what lets the automatic adjoint differentiate through mass balance, and it removes the operator splitting error a periodic jump introduces.
+so a model supplies a **rate**, evaluated at every step of the solve — not an increment applied by a callback. That's what lets the automatic adjoint differentiate through mass balance, and it removes the operator-splitting error a periodic jump introduces.
 
-Evaluating a model inside the right hand side is not free. It runs orders of magnitude more often than a monthly callback did, it may not read the climate rasters (`Rasters` is not differentiable and not cheap), and it has to be differentiable with respect to `H`. The climate is therefore precomputed per mass balance window when the cache is built, and the model reads that.
+Evaluating a model inside the right hand side isn't free: it runs far more often than a monthly callback did, can't read the climate rasters (`Rasters` isn't differentiable and isn't cheap), and must be differentiable in `H`. So climate is precomputed per mass balance window when the cache is built, and the model reads that.
 
 ```
 Every RHS call:

--- a/docs/src/extending.md
+++ b/docs/src/extending.md
@@ -128,14 +128,24 @@ end
 
 ## Add a new mass balance model
 
-New mass balance models subtype `MBmodel` (defined in `Muninn`). The MB callback fires every `step_MB` and runs three steps in sequence — only `compute_MB` is model-specific:
+New mass balance models subtype `MBmodel` (defined in `Muninn`). Mass balance is a source term of the ice flow right hand side,
+
+```math
+\frac{\partial H}{\partial t} = -\nabla\cdot(D\nabla S) + \dot m(H, t)
+```
+
+so a model supplies a **rate**, evaluated at every step of the solve, rather than an increment applied by a callback. There is no mass balance callback: that is what lets the automatic adjoint differentiate through mass balance, and it removes the operator splitting error a periodic jump introduces.
+
+Evaluating a model inside the right hand side is not free. It runs orders of magnitude more often than a monthly callback did, it may not read the climate rasters (`Rasters` is not differentiable and not cheap), and it has to be differentiable with respect to `H`. The climate is therefore precomputed per mass balance window when the cache is built, and the model reads that.
 
 ```
-MB callback (every step_MB):
-  ├── MB_timestep!(cache, model, glacier, step, t, glacier_idx)  # writes the MB into cache.iceflow.MB
-  │     └── compute_MB(mb_model, climate_2D_step, step)     ← implement this for your model
-  ├── apply_MB_mask!(H, cache.iceflow)                      # applies the MB to the ice thickness H, clipping to avoid negative thickness
-  └── push!(cache.iceflow.MB_history, copy(cache.iceflow.MB))   # records the MB snapshot
+Every RHS call:
+  └── add_MB!(dH, H, simulation, t)
+        └── MB_rate!(ṁ, H, mb_cache, mb_model, glacier, t)   ← implement this for your model
+              (mb_cache carries the precomputed climate for the window containing t)
+
+Once per simulation, per glacier:
+  └── init_mb_cache(mb_model, simulation, glacier_idx, θ)    ← and this
 ```
 
 **Minimum to implement:**
@@ -147,7 +157,31 @@ struct MyMBmodel <: MBmodel
     # your fields
 end
 
-# Required: compute the distributed MB for one time step
+# How the rate depends on the ice surface S, which decides how it can be evaluated.
+# :elevation_only means it depends on S only through the scalar offset ΔS = S - ref_hgt,
+# which is what makes a lookup table possible. Anything else is :general, the default.
+Muninn.mb_S_dependence(::MyMBmodel) = :general
+
+# Precompute whatever the RHS needs so that the solve never touches the climate rasters.
+function Sleipnir.init_mb_cache(model::MyMBmodel, simulation, glacier_idx::Integer, θ)
+    # return your cache type, or an empty one when use_MB is false
+end
+
+# The rate, in m of ice per year, written in place. Called at every step of the solve.
+function Muninn.MB_rate!(ṁ, H, cache, model::MyMBmodel, glacier, t::Real)
+    # ṁ[i, j] = ...
+end
+
+# Required to take gradients through the model with the manual adjoints. Free under
+# SciMLSensitivityAdjoint, which differentiates MB_rate! itself.
+function Muninn.MB_rate_∂H!(∂ṁ, H, cache, model::MyMBmodel, glacier, t::Real)
+    # ∂ṁ[i, j] = ∂ṁ[i, j] / ∂H[i, j]   (diagonal: a cell depends only on its own H)
+end
+```
+
+`compute_MB` is still required, and is unchanged:
+
+```julia
 function Muninn.compute_MB(model::MyMBmodel, climate_step::Climate2Dstep,
         step::AbstractFloat)
     # climate_step — gridded climate fields (temp, prcp, PDD, etc.)
@@ -155,6 +189,16 @@ function Muninn.compute_MB(model::MyMBmodel, climate_step::Climate2Dstep,
     # return a (nx, ny) matrix in m w.e.
 end
 ```
+
+It is what `calibrate_MB_model` fits parameters against, and what the test suite checks `MB_rate!` agrees with. If the two ever drift apart, the model being calibrated stops being the model being integrated, which nothing else guards against.
+
+!!! note "Positivity is the model's responsibility"
+
+    `ṁ` must vanish as `H` approaches zero, or a cell melts through the bed. `TImodel1` does this with a cubic `smoothstep` ramp on the rate, which is C¹ with a bounded derivative — a hard mask would be a step discontinuity in the state that no adaptive error controller can resolve and no adjoint can differentiate. See `mass_balance_rhs.jl` in Muninn.
+
+!!! warning "Only `TImodel1` has a right hand side form today"
+
+    `mb_S_dependence` defaults to `:general`, and the `:general` branch of `MB_rate!` is not implemented yet, so a model that does not opt into `:elevation_only` currently throws when the cache is built. Implementing it is tracked as its own piece of work.
 
 **Optional dispatch hooks** (all have sensible defaults in Muninn — override only what differs):
 
@@ -170,7 +214,7 @@ Pass your model to `Model(; iceflow = iceflow_model, mass_balance = MyMBmodel(..
 
 !!! warning "TImodel2 is not yet fully implemented"
 
-    `TImodel2` (separate snow/ice DDFs) is declared and exported in Muninn but has no `compute_MB` dispatch. A simulation built with `TImodel2` will fail at the first MB callback. Full implementation is tracked in a separate Muninn issue.
+    `TImodel2` (separate snow/ice DDFs) is declared and exported in Muninn but has no `compute_MB` dispatch, and no right hand side form either. A simulation built with `TImodel2` fails when the mass balance cache is built. Full implementation is tracked in a separate Muninn issue.
 
 * * *
 

--- a/docs/src/functional_inversion.jl
+++ b/docs/src/functional_inversion.jl
@@ -238,3 +238,49 @@ plot_law(functional_inversion.model.iceflow.A, functional_inversion, law_input, 
 # Just to have some additional context, here is how the synthetic law looks like for the full range of temperatures:
 plot_law(prediction.model.iceflow.A, prediction,
     law_input, nothing; plot_full_input_range = true)
+
+# ## Training with mass balance
+
+# The inversion above runs with `use_MB = false`. Turning mass balance on needs no change to
+# how the gradient is computed, because mass balance is a source term of the ice flow right
+# hand side rather than a periodic jump applied to the ice thickness:
+
+# ```math
+# \frac{\partial H}{\partial t} = -\nabla\cdot(D\nabla S) + \dot m(H, t)
+# ```
+
+# So it is differentiated like any other term of the right hand side, and both adjoints
+# support it:
+
+# ```julia
+# params = Parameters(
+#     simulation = SimulationParameters(
+#         use_MB = true,          # mass balance on
+#         tspan = tspan,
+#         rgi_paths = rgi_paths,
+#     ),
+#     UDE = UDEparameters(
+#         grad = SciMLSensitivityAdjoint(),   # or ContinuousAdjoint()
+#         optim_autoAD = ODINN.NoAD(),
+#         optimization_method = "AD+AD",
+#     ),
+# )
+# model = Model(
+#     iceflow = SIA2Dmodel(params; A = law_A),
+#     mass_balance = TImodel1(params; DDF = 6.0 / 1000.0, prcp_fac = 1.2),
+#     regressors = (; A = nn_model),
+# )
+# ```
+
+# `SciMLSensitivityAdjoint` with mass balance was not possible before: differentiating the
+# periodic callback that applied it was unsupported, so mass balance and the automatic
+# adjoint were mutually exclusive.
+
+# Note that the mass balance rate depends on the ice thickness through the surface `S = B + H`, so
+# `∂ṁ/∂H` is nonzero and reaches the gradient with respect to `A` even though no mass
+# balance parameter is being trained. That elevation feedback is what the gradient tests in
+# `test/runtests.jl` (group `Core12`) check against finite differences, for both adjoints.
+
+# Only mass balance models with a right hand side form can be used this way, which today
+# means `TImodel1`. See [Add a new mass balance model](./extending.md) for the interface a
+# new model has to implement.

--- a/docs/src/functional_inversion.jl
+++ b/docs/src/functional_inversion.jl
@@ -276,7 +276,7 @@ plot_law(prediction.model.iceflow.A, prediction,
 # periodic callback that applied it was unsupported, so mass balance and the automatic
 # adjoint were mutually exclusive.
 
-# Note that the mass balance rate depends on the ice thickness through the surface `S = B + H`, so
+# The mass balance rate depends on the ice thickness through the surface `S = B + H`, so
 # `∂ṁ/∂H` is nonzero and reaches the gradient with respect to `A` even though no mass
 # balance parameter is being trained. That elevation feedback is what the gradient tests in
 # `test/runtests.jl` (group `Core12`) check against finite differences, for both adjoints.

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -87,6 +87,10 @@ model = Model(
 
 `CustomMLP` is a subtype of `MBmodel` and wraps a `Lux.jl` feedforward network whose architecture, input feature normalisation bounds, and pre-trained weights are all read directly from the JSON export. The network takes monthly ERA5 climate features as inputs (e.g. `t2m`, `tp`, `ssrd`, …) and outputs a surface mass balance rate in m w.e. per time step. For now, only monthly time steps are supported. It is the *de facto* data-driven surface mass balance model in the ODINN ecosystem.
 
+!!! warning "Not yet usable in a simulation"
+
+    Mass balance is evaluated as a source term of the ice flow right hand side, and only models that declare `mb_S_dependence` as `:elevation_only` have that form today — in practice `TImodel1`. `CustomMLP` reads several fields, so it falls to the `:general` branch, which is not implemented: building a simulation with it and `use_MB = true` raises an error naming the functions to implement. See [Add a new mass balance model](@ref) for the interface.
+
 Once loaded, models can be saved to a local registry to avoid re-parsing JSON on subsequent runs:
 
 ```julia

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -34,7 +34,7 @@ Muninn.TImodel1
 Muninn.TImodel1(params::Sleipnir.Parameters)
 ```
 
-Surface mass balance models are run in `DiscreteCallback`s from `OrdinaryDiffEq.jl`, which enable the safe execution during the solving of a PDE in specifically prescribed time steps determined in the `steps` field in [`Sleipnir.SimulationParameters`](@ref).
+Surface mass balance is evaluated as a source term of the ice flow right hand side, `∂H/∂t = -∇·(D∇S) + ṁ(H, t)`, at every step of the solve rather than through a callback — see [Add a new mass balance model](@ref) for the model interface this requires.
 
 ### Calibrating a temperature-index model
 

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -34,10 +34,24 @@ Given a loss function $L(\theta)$ (see the [Optimization](./optimization.md) sec
     - \nabla \cdot \left( D \nabla \lambda \right)
     + \frac{\partial D}{\partial H} \nabla S \cdot \nabla \lambda
     - \nabla \cdot \left( \frac{\partial D}{\partial (\nabla H)} \nabla S \cdot \nabla \lambda \right)
+    - \frac{\partial \dot m}{\partial H} \lambda
     - \frac{\partial \ell}{\partial H}
 ```
 
 with final condition $\lambda(x,y,t_1) = 0$ and $\lambda |_{\partial \Omega} \equiv 0$.
+
+The mass balance term $\dot m$ is a source term of the forward equation, so its sensitivity
+enters the adjoint the same way any other term of the right hand side does. It is *local*:
+the rate at a cell depends on the surface only through that cell, so
+$\partial \dot m / \partial H$ is diagonal and the contribution is an elementwise product
+rather than an operator. Note it is not zero even when no mass balance parameter is trained,
+since $\dot m$ depends on $H$ through the surface $S = B + H$, and that dependence reaches
+the gradient with respect to ice flow parameters such as $A$.
+
+Applying mass balance as a periodic jump instead would put a discontinuity in the trajectory,
+which the adjoint would have to be told about explicitly and which
+`SciMLSensitivity` could not differentiate through at all. Evaluating it in the right hand
+side is what removes that special case.
 The gradient of the loss function $L(\theta)$ with respect to the parameter $\theta$ then can be computed using the following expression:
 
 ```math

--- a/scripts/forward_simulation_custommlp.jl
+++ b/scripts/forward_simulation_custommlp.jl
@@ -1,3 +1,9 @@
+# DOES NOT RUN YET. Mass balance is evaluated as a source term of the ice flow RHS, and only
+# models whose `mb_S_dependence` is `:elevation_only` have that form — in practice `TImodel1`.
+# `CustomMLP` reads several fields, so it falls to the `:general` branch, which is a stub:
+# building the simulation below raises an error naming the functions to implement.
+# Tracked in https://github.com/ODINN-SciML/Muninn.jl/issues/72.
+
 using Pkg
 
 Pkg.activate(normpath(joinpath(@__DIR__, "..")))

--- a/src/inverse/SIA2D/VJPs.jl
+++ b/src/inverse/SIA2D/VJPs.jl
@@ -82,8 +82,8 @@ is not evaluated in the right hand side. The Enzyme VJP differentiates the right
 directly and so already accounts for this term.
 
 Dispatches on the mass balance VJP method so that `NoVJP` drops the elevation feedback. That
-is what gives the gradient tests teeth: a threshold worth having is one the feedback-free
-gradient fails.
+is what a negative control for the gradient tests needs: a threshold worth having is one the
+feedback-free gradient fails.
 """
 λ_∂ṁ∂H(::NoVJP, λ, H, simulation::Simulation, t) = zero(λ)
 

--- a/src/inverse/SIA2D/VJPs.jl
+++ b/src/inverse/SIA2D/VJPs.jl
@@ -1,12 +1,14 @@
 
 function VJP_λ_∂SIA∂H(VJPMode::DiscreteVJP, λ, H, θ, simulation::Simulation, t)
     λ_∂f∂H = VJP_λ_∂SIA∂H_discrete(λ, H, θ, simulation, t)
-    return λ_∂f∂H, nothing
+    λ_MB = λ_∂ṁ∂H(simulation.parameters.UDE.grad.MB_VJP, λ, H, simulation, t)
+    return λ_∂f∂H .+ λ_MB, nothing
 end
 
 function VJP_λ_∂SIA∂H(VJPMode::ContinuousVJP, λ, H, θ, simulation::Simulation, t)
     λ_∂f∂H = VJP_λ_∂SIA∂H_continuous(λ, H, θ, simulation, t)
-    return λ_∂f∂H, nothing
+    λ_MB = λ_∂ṁ∂H(simulation.parameters.UDE.grad.MB_VJP, λ, H, simulation, t)
+    return λ_∂f∂H .+ λ_MB, nothing
 end
 
 function VJP_λ_∂SIA∂H(VJPMode::EnzymeVJP, λ, H, θ, simulation::Simulation, t)
@@ -66,6 +68,36 @@ end
 function VJP_λ_∂surface_V∂θ(VJPMode::DiscreteVJP, λx, λy, H, θ, simulation, t)
     λ_∂V∂H = VJP_λ_∂surface_V∂θ_discrete(λx, λy, H, θ, simulation, t)
     return λ_∂V∂H, nothing
+end
+
+"""
+    λ_∂ṁ∂H(VJPMode::AbstractVJPMethod, λ, H, simulation::Simulation, t)
+
+Contribution of the mass balance source term to the vector-Jacobian product of the ice flow
+right hand side.
+
+The mass balance rate at a cell depends only on that cell's ice thickness, so its Jacobian is
+diagonal and the product is an elementwise multiplication. Returns zero when the mass balance
+is not evaluated in the right hand side. The Enzyme VJP differentiates the right hand side
+directly and so already accounts for this term.
+
+Dispatches on the mass balance VJP method so that `NoVJP` drops the elevation feedback. That
+is what gives the gradient tests teeth: a threshold worth having is one the feedback-free
+gradient fails.
+"""
+λ_∂ṁ∂H(::NoVJP, λ, H, simulation::Simulation, t) = zero(λ)
+
+function λ_∂ṁ∂H(::AbstractVJPMethod, λ, H, simulation::Simulation, t)
+    mb_cache = simulation.cache.mass_balance
+    mb_cache_active(mb_cache) || return zero(λ)
+
+    glacier_idx = simulation.cache.iceflow.glacier_idx
+    glacier = simulation.glaciers[glacier_idx]
+    mb_model = get_mb_model(simulation.model.mass_balance, glacier_idx)
+
+    ∂ṁ = similar(H)
+    MB_rate_∂H!(∂ṁ, H, mb_cache, mb_model, glacier, t)
+    return ∂ṁ .* λ
 end
 
 function MB_wrapper!(MB, H, simulation, glacier, mb_model, step)

--- a/src/inverse/SIA2D/gradient.jl
+++ b/src/inverse/SIA2D/gradient.jl
@@ -127,17 +127,6 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
             simulation.model.iceflow, simulation.cache.iceflow, simulation, i, tspan[2], θ)
 
         if typeof(simulation.parameters.UDE.grad) <: DiscreteAdjoint
-            # Only the discrete scheme applies the mass balance as a jump. As a source term
-            # it is already part of the SIA VJP, so there are no MB stops to align with.
-            tstopsMB = if simulation.parameters.simulation.use_MB &&
-                          simulation.parameters.simulation.MB_scheme == :discrete
-                tstopsMB = Huginn.define_callback_steps(tspan, simulation.parameters.simulation.step_MB)[2:end] # Discard first time step to be aligned with the forward
-                @assert all(map(ti -> ti in t, tstopsMB)) "When using the DiscreteAdjoint the tstops of the MB callback must all be included in the tstops from the results."
-                tstopsMB
-            else
-                []
-            end
-
             # Adjoint setup
             # Define empty object to store adjoint in reverse mode
             λ = [zero(result.B) for _ in 1:k]
@@ -201,17 +190,9 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
                     V = isnothing(indVelocity) ? 0.0 : safe_slice(Δt_HV.V, indVelocity-1)
                 )
 
-                # State at which the SIA VJP is linearized. At an MB step the SIA flow over
-                # the interval ends at the pre-MB state, so undo the MB increment here.
+                # Mass balance is a source term of the RHS, so it is already inside the SIA
+                # VJP and the stored state is the one to linearize on.
                 H_SIA = H[j]
-                if simulation.parameters.simulation.use_MB && (tj in tstopsMB)
-                    # Retrieve H before MB callback because the solution is stored only after MB has been applied
-                    indMB = findfirst(result.t_MB .== tj)
-                    H_preMB = H[j] - result.MB[indMB]
-                    λ[j] .+= VJP_λ_∂MB∂H(simulation.parameters.UDE.grad.MB_VJP,
-                        λ[j], H_preMB, simulation, glacier, tj)
-                    H_SIA = H_preMB
-                end
 
                 # Compute derivative of local contribution to loss function
                 ∂ℓ∂H = ∂L∂H[j]
@@ -313,27 +294,6 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
                 throw("Interpolation method for continuous adjoint not defined.")
             end
 
-            # Linear interpolant (as above) used only for the SIA VJP linearization. The forward SIA flow over
-            # each interval ends at the pre-MB state (MB is applied at the right endpoint),
-            # but H stores post-MB states. Interpolate post-MB at the left node and pre-MB at
-            # the right node so the SIA VJP is linearized on the true forward trajectory.
-            H_itp_SIA = if simulation.parameters.simulation.use_MB &&
-                           simulation.parameters.simulation.MB_scheme == :discrete
-                H_preMB_nodes = map(eachindex(t)) do j
-                    indMB = findfirst(result.t_MB .== t[j])
-                    isnothing(indMB) ? H[j] : H[j] .- result.MB[indMB]
-                end
-                let t = t, H = H, H_preMB_nodes = H_preMB_nodes
-                    function (tq)
-                        j = clamp(searchsortedlast(t, tq), firstindex(t), lastindex(t) - 1)
-                        frac = (tq - t[j]) / (t[j + 1] - t[j])
-                        H[j] .+ frac .* (H_preMB_nodes[j + 1] .- H[j])
-                    end
-                end
-            else
-                H_itp
-            end
-
             # Nodes and weights for numerical quadrature
             t_nodes,
             weights = GaussQuadrature(tspan..., simulation.parameters.UDE.grad.n_quadrature)
@@ -344,12 +304,12 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
                  (typeof(simulation.parameters.UDE.grad.VJP_method) <: ContinuousVJP))
                 throw("VJP method $(simulation.parameters.UDE.grad.VJP_method) is not supported yet.")
             end
-            f_adjoint_rev = let simulation=simulation, H_itp_SIA=H_itp_SIA, θ=θ
+            f_adjoint_rev = let simulation=simulation, H_itp=H_itp, θ=θ
                 function (dλ, λ, p, τ)
                     t = -τ
                     λ_∂f∂H,
                     _ = VJP_λ_∂SIA∂H(simulation.parameters.UDE.grad.VJP_method,
-                        λ, H_itp_SIA(t), θ, simulation, t)
+                        λ, H_itp(t), θ, simulation, t)
                     dλ .= λ_∂f∂H
                 end
             end
@@ -442,29 +402,9 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
                 CallbackSet()
             end
 
-            # Mass balance contribution
-            effect_MB! = let simulation=simulation, glacier=glacier, H_itp=H_itp
-                function (integrator)
-                    t = - integrator.t
-                    # Retrieve H before MB callback because the solution is stored only after MB has been applied
-                    indMB = findfirst(result.t_MB .== t)
-                    H_preMB = H_itp(t) - result.MB[indMB]
-                    λ_∂MB∂H = VJP_λ_∂MB∂H(simulation.parameters.UDE.grad.MB_VJP,
-                        integrator.u, H_preMB, simulation, glacier, t)
-                    integrator.u .+= λ_∂MB∂H
-                end
-            end
-            cb_adjoint_MB = if simulation.parameters.simulation.use_MB &&
-                               simulation.parameters.simulation.MB_scheme == :discrete
-                # For the moment the time stepping used in the loss, and the one for the MB gradient computation must match
-                # The plan in the future is to be able to customize the time stepping for the MB gradient computation
-                # Cf https://github.com/ODINN-SciML/ODINN.jl/issues/373
-                PeriodicCallback(effect_MB!, simulation.parameters.simulation.step_MB;
-                    initial_affect = true, final_affect = false) # Exchange the role of initial_affect/final_affect in comparison to the forward
-            else
-                CallbackSet()
-            end
-            cb = CallbackSet(cb_adjoint_MB, cb_adjoint_loss, cb_adjoint_aggregated_loss)
+            # Mass balance needs no callback of its own: it is a source term of the ice flow
+            # RHS, so its contribution reaches the adjoint through the SIA VJP.
+            cb = CallbackSet(cb_adjoint_loss, cb_adjoint_aggregated_loss)
 
             # Final condition
             λ₁ = zero(H[end])
@@ -526,7 +466,7 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
                Union{DiscreteVJP, EnzymeVJP, ContinuousVJP}
                 for j in 1:length(t_nodes)
                     λ_sol = sol_rev(- t_nodes[j])
-                    _H = H_itp_SIA(t_nodes[j])
+                    _H = H_itp(t_nodes[j])
                     λ_∂f∂θ = VJP_λ_∂SIA∂θ(simulation.parameters.UDE.grad.VJP_method,
                         λ_sol, _H, θ, nothing, simulation, t_nodes[j])
                     dLdθ .+= weights[j] .* (λ_∂f∂θ .+ ∂L∂θ[j])

--- a/src/inverse/SIA2D/gradient.jl
+++ b/src/inverse/SIA2D/gradient.jl
@@ -478,10 +478,9 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
             # Compute gradient wrt initial condition because this is not taken into account in the quadrature
             if haskey(θ, :IC)
                 λ₀ = copy(sol_rev(-tspan[1]))
-                # The callbacks do deposit the t₀ loss during the reverse solve, but
-                # `sol_rev` interpolated at -tspan[1] does not carry that jump. Since
-                # dL/dH₀ = λ(t₀⁻) must include it, apply it explicitly here; otherwise the
-                # initial-condition gradient is too small.
+                # The callbacks deposit the t₀ loss during the reverse solve, but `sol_rev`
+                # at -tspan[1] doesn't carry that jump. dL/dH₀ = λ(t₀⁻) needs it, so apply
+                # it explicitly — otherwise the initial-condition gradient comes out too small.
                 if tspan[1] ∈ tstops
                     effect_loss!(tspan[1], λ₀)
                 end

--- a/src/inverse/SIA2D/gradient.jl
+++ b/src/inverse/SIA2D/gradient.jl
@@ -127,7 +127,10 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
             simulation.model.iceflow, simulation.cache.iceflow, simulation, i, tspan[2], θ)
 
         if typeof(simulation.parameters.UDE.grad) <: DiscreteAdjoint
-            tstopsMB = if simulation.parameters.simulation.use_MB
+            # Only the discrete scheme applies the mass balance as a jump. As a source term
+            # it is already part of the SIA VJP, so there are no MB stops to align with.
+            tstopsMB = if simulation.parameters.simulation.use_MB &&
+                          simulation.parameters.simulation.MB_scheme == :discrete
                 tstopsMB = Huginn.define_callback_steps(tspan, simulation.parameters.simulation.step_MB)[2:end] # Discard first time step to be aligned with the forward
                 @assert all(map(ti -> ti in t, tstopsMB)) "When using the DiscreteAdjoint the tstops of the MB callback must all be included in the tstops from the results."
                 tstopsMB
@@ -314,7 +317,8 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
             # each interval ends at the pre-MB state (MB is applied at the right endpoint),
             # but H stores post-MB states. Interpolate post-MB at the left node and pre-MB at
             # the right node so the SIA VJP is linearized on the true forward trajectory.
-            H_itp_SIA = if simulation.parameters.simulation.use_MB
+            H_itp_SIA = if simulation.parameters.simulation.use_MB &&
+                           simulation.parameters.simulation.MB_scheme == :discrete
                 H_preMB_nodes = map(eachindex(t)) do j
                     indMB = findfirst(result.t_MB .== t[j])
                     isnothing(indMB) ? H[j] : H[j] .- result.MB[indMB]
@@ -450,7 +454,8 @@ function SIA2D_grad_batch!(θ, simulation::Inversion)
                     integrator.u .+= λ_∂MB∂H
                 end
             end
-            cb_adjoint_MB = if simulation.parameters.simulation.use_MB
+            cb_adjoint_MB = if simulation.parameters.simulation.use_MB &&
+                               simulation.parameters.simulation.MB_scheme == :discrete
                 # For the moment the time stepping used in the loss, and the one for the MB gradient computation must match
                 # The plan in the future is to be able to customize the time stepping for the MB gradient computation
                 # Cf https://github.com/ODINN-SciML/ODINN.jl/issues/373

--- a/src/laws/Laws.jl
+++ b/src/laws/Laws.jl
@@ -407,11 +407,10 @@ value of `scalar`.
 function LawA(params::Sleipnir.Parameters; scalar::Bool = true)
     min_A = params.physical.minA
     max_A = params.physical.maxA
-    # SciMLSensitivity's InterpolatingAdjoint computes VJPs by replaying the RHS at each
-    # adjoint step, so the law must be evaluated at every RHS call for the gradient to flow
-    # through θ → A → D. callback_freq=nothing ensures this. For manual adjoints (e.g.
-    # ContinuousAdjoint), callback_freq=0 applies A once via a callback and the gradient
-    # is handled analytically via p_VJP!.
+    # SciMLSensitivity's InterpolatingAdjoint replays the RHS at each adjoint step, so the
+    # law must run at every RHS call for the gradient to flow through θ → A → D —
+    # callback_freq = nothing ensures that. Manual adjoints (e.g. ContinuousAdjoint) apply A
+    # once via a callback (callback_freq = 0) and handle the gradient analytically via p_VJP!.
     callback_freq = if isa(params.UDE.grad, DummyAdjoint) ||
                        isa(params.UDE.grad, SciMLSensitivityAdjoint)
         nothing

--- a/src/simulations/inversions/inversion_utils.jl
+++ b/src/simulations/inversions/inversion_utils.jl
@@ -326,11 +326,6 @@ Compute the gradient with respect to θ for all the glaciers and return the resu
 See the in-place implementation for more information.
 """
 function grad_loss_iceflow!(θ, simulation::Inversion, mappingFct)
-    if simulation.parameters.simulation.use_MB &&
-       simulation.parameters.simulation.MB_scheme == :discrete
-        @assert simulation.parameters.UDE.optim_autoAD isa NoAD "Differentiation of callbacks with SciMLStruct is not supported by SciMLSensitivity yet. You get this error because you are using MB + gradient computation with SciMLSensitivity. Use MB_scheme = :continuous to evaluate the mass balance in the ice flow right hand side instead."
-    end
-
     simulation.model.trainable_components.θ = θ
     simulations = generate_simulation_batches(simulation)
     grads = mappingFct(simulations) do simulation
@@ -505,31 +500,6 @@ function _batch_iceflow_UDE(
     tstops = sort(unique(vcat(tstops, tstopsIceThickness, tstopsVelocity,
         tstopsDiscreteLoss, tstopsAggregatedLoss)))
 
-    # Create mass balance callback. Not needed when the mass balance is a source term of the
-    # ice flow right hand side, which is the whole point: no callback left to differentiate.
-    cb_MB = if params.simulation.use_MB &&
-               params.simulation.MB_scheme == :discrete
-        # For the moment there is a bug when we use callbacks with SciMLSensitivity for the gradient computation
-        mb_action! = let model = container.simulation.model,
-            cache = container.simulation.cache, glacier = glacier, step_MB = step_MB,
-            glacier_idx = glacier_idx
-
-            function (integrator)
-                # Compute mass balance
-                glacier.S .= glacier.B .+ integrator.u
-                MB_timestep!(cache, model, glacier, step_MB, integrator.t, glacier_idx)
-                apply_MB_mask!(integrator.u, cache.iceflow)
-                push!(cache.iceflow.MB_history, copy(cache.iceflow.MB))
-                push!(cache.iceflow.MB_times, integrator.t)
-            end
-        end
-        # A simulation period is sliced in time windows that are separated by `step_MB`
-        # The mass balance is applied at the end of each of the windows
-        PeriodicCallback(mb_action!, step_MB; initial_affect = false, final_affect = true)
-    else
-        CallbackSet()
-    end
-
     # Create iceflow law callback
     cb_iceflow = Huginn.build_callback(
         container.simulation.model.iceflow,
@@ -539,7 +509,8 @@ function _batch_iceflow_UDE(
         params.simulation.tspan
     )
 
-    cb = CallbackSet(cb_MB, cb_iceflow)
+    # Mass balance is a source term of the ice flow RHS, so there is no callback for it
+    cb = CallbackSet(cb_iceflow)
 
     # Run iceflow UDE for this glacier
     iceflow_sol = simulate_iceflow_UDE!(container, cb, iceflow_prob, tstops)

--- a/src/simulations/inversions/inversion_utils.jl
+++ b/src/simulations/inversions/inversion_utils.jl
@@ -326,8 +326,9 @@ Compute the gradient with respect to θ for all the glaciers and return the resu
 See the in-place implementation for more information.
 """
 function grad_loss_iceflow!(θ, simulation::Inversion, mappingFct)
-    if simulation.parameters.simulation.use_MB
-        @assert simulation.parameters.UDE.optim_autoAD isa NoAD "Differentiation of callbacks with SciMLStruct is not supported by SciMLSensitivity yet. You get this error because you are using MB + gradient computation with SciMLSensitivity."
+    if simulation.parameters.simulation.use_MB &&
+       simulation.parameters.simulation.MB_scheme == :discrete
+        @assert simulation.parameters.UDE.optim_autoAD isa NoAD "Differentiation of callbacks with SciMLStruct is not supported by SciMLSensitivity yet. You get this error because you are using MB + gradient computation with SciMLSensitivity. Use MB_scheme = :continuous to evaluate the mass balance in the ice flow right hand side instead."
     end
 
     simulation.model.trainable_components.θ = θ
@@ -504,8 +505,10 @@ function _batch_iceflow_UDE(
     tstops = sort(unique(vcat(tstops, tstopsIceThickness, tstopsVelocity,
         tstopsDiscreteLoss, tstopsAggregatedLoss)))
 
-    # Create mass balance callback
-    cb_MB = if params.simulation.use_MB
+    # Create mass balance callback. Not needed when the mass balance is a source term of the
+    # ice flow right hand side, which is the whole point: no callback left to differentiate.
+    cb_MB = if params.simulation.use_MB &&
+               params.simulation.MB_scheme == :discrete
         # For the moment there is a bug when we use callbacks with SciMLSensitivity for the gradient computation
         mb_action! = let model = container.simulation.model,
             cache = container.simulation.cache, glacier = glacier, step_MB = step_MB,
@@ -543,10 +546,15 @@ function _batch_iceflow_UDE(
 
     # Compute simulation results
     # No need to generate the velocities since this is automatically computed directly inside the loss function when needed
+    # Diagnostics only, and it writes into the mass balance cache, so keep it out of the
+    # differentiated region
+    MB,
+    t_MB = Zygote.@ignore_derivatives Huginn.MB_diagnostics(
+        container.simulation, iceflow_sol)
     return Sleipnir.create_results(
         container.simulation, glacier_idx, iceflow_sol, tstops;
-        MB = container.simulation.cache.iceflow.MB_history,
-        t_MB = container.simulation.cache.iceflow.MB_times,
+        MB = MB,
+        t_MB = t_MB,
         processVelocity = processVelocity
     )
 end
@@ -568,16 +576,26 @@ function simulate_iceflow_UDE!(
         tstops
 )
     params = container.simulation.parameters
+    solver_tstops, saveat = Huginn.MB_solver_stops(container.simulation, tstops)
+    # `dt` only when stepping is fixed: in adaptive mode supplying one overrides the solver's
+    # own initial step, and supplying zero aborts the solve.
+    step_kw = params.solver.adaptive ? NamedTuple() : (; dt = params.solver.dt)
     iceflow_prob_remake = remake(iceflow_prob; p = container)
     iceflow_sol = solve(
         iceflow_prob_remake,
-        params.solver.solver,
+        Huginn.with_eigen_est(params.solver.solver, container.simulation);
         callback = cb,
         sensealg = params.UDE.sensealg,
         reltol = params.solver.reltol,
+        abstol = params.solver.scale_abstol ?
+                 Huginn.effective_abstol(params.solver.abstol, params.simulation.tspan;
+            verbose = false) : params.solver.abstol,
+        adaptive = params.solver.adaptive,
+        saveat = saveat,
         progress = false,
         maxiters = params.solver.maxiters,
-        tstops = tstops
+        tstops = solver_tstops,
+        step_kw...
     )
     @assert iceflow_sol.retcode==ReturnCode.Success "There was an error in the iceflow solver. Returned code is \"$(iceflow_sol.retcode)\""
 

--- a/test/gradient_diagnostics.jl
+++ b/test/gradient_diagnostics.jl
@@ -1,0 +1,116 @@
+# Manual, non-CI groups for investigating the mass balance gradient by hand — step-size and
+# tolerance sweeps that print rather than assert, plus one negative control. Run one with
+# `GROUP=<name> julia test/runtests.jl`. None of these appear in .github/workflows/CI*.yml.
+
+if GROUP == "GradTolGrid"
+    # The scalar case cannot show direction bias: θ feeds a network with a single scalar
+    # output, so every gradient is parallel to ∂A/∂θ whatever the solver does. A gridded
+    # inversion gives θ one component per cell, where the direction is free to move.
+    common = (; use_MB = true, A_range = (2e-18, 8e-18),
+        solver = ROCK2(), functional_inv = false, scalar = false, return_grad = true)
+    b = collect(test_grad_finite_diff(
+        ContinuousAdjoint(VJP_method = DiscreteVJP()); abstol = 1e-6, common...))
+    @printf("  reference |g| = %.6e over %d components (ROCK2, abstol 1e-6)\n",
+        norm(b), length(b))
+    for atol in (1e-5, 1e-4, 1e-3, 1e-2)
+        g = collect(test_grad_finite_diff(
+            ContinuousAdjoint(VJP_method = DiscreteVJP()); abstol = atol, common...))
+        cosang = dot(g, b) / (norm(g) * norm(b))
+        @printf("  abstol=%.0e  |g|=%.6e  rel|g|=%.2e  angle=%.3e rad (%.3f deg)  relerr=%.2e\n",
+            atol, norm(g), abs(norm(g) - norm(b)) / norm(b),
+            acos(clamp(cosang, -1, 1)), rad2deg(acos(clamp(cosang, -1, 1))),
+            norm(g .- b) / norm(b))
+    end
+end
+
+if GROUP == "GradTol"
+    # Diagnostic. Everything else measures H accuracy; for an inversion what matters is
+    # whether a loose tolerance biases the GRADIENT. Direction error is reported apart
+    # from magnitude because an optimiser follows the direction.
+    base = test_grad_finite_diff(
+        ContinuousAdjoint(VJP_method = DiscreteVJP()); use_MB = true,
+        A_range = (2e-18, 8e-18), solver = ROCK2(),
+        abstol = 1e-6, return_grad = true)
+    b = collect(base)
+    println("  reference |g| = ", norm(b), "   (ROCK2, abstol 1e-6)")
+    for atol in (1e-5, 1e-4, 1e-3, 1e-2)
+        g = collect(test_grad_finite_diff(
+            ContinuousAdjoint(VJP_method = DiscreteVJP()); use_MB = true,
+            A_range = (2e-18, 8e-18), solver = ROCK2(),
+            abstol = atol, return_grad = true))
+        cosang = dot(g, b) / (norm(g) * norm(b))
+        @printf("  abstol=%.0e  |g|=%.6e  rel|g| err=%.2e  angle=%.2e rad  relerr=%.2e\n",
+            atol, norm(g), abs(norm(g) - norm(b)) / norm(b),
+            acos(clamp(cosang, -1, 1)), norm(g .- b) / norm(b))
+    end
+end
+
+if GROUP == "Core12NegativeControl"
+    # Not part of any suite: it is expected to FAIL, and that is the point. Dropping the
+    # elevation feedback must break the threshold the correct adjoints pass, otherwise
+    # that threshold demonstrates nothing about the mass balance term.
+    @testset "Negative control: elevation feedback removed (expected to fail)" test_grad_finite_diff(
+        ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = NoVJP());
+        use_MB = true, A_range = (2e-18, 8e-18),
+        adaptive = false, dt = 1.0/240.0, fd_delta = 1e-9, thres_fd = 5e-3)
+end
+
+if GROUP == "Core3MB"
+    # The mass balance gradient cases of Core3 on their own, with the same settings:
+    # Core3 takes over an hour and most of it is unrelated to them.
+    mb_fd = (adaptive = false, dt = 1.0/240.0, fd_delta = 1e-5, thres_fd = 5e-3)
+    @testset "MB gradient cases" begin
+        @testset "Enzyme MB VJP" test_grad_finite_diff(
+            ContinuousAdjoint(
+                VJP_method = DiscreteVJP(regressorADBackend = DI.AutoZygote()),
+                MB_VJP = ODINN.EnzymeVJP());
+            thres = [3e-3, 1e-8, 3e-3], use_MB = true, mb_fd...)
+        @testset "discrete MB VJP" test_grad_finite_diff(
+            ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
+            thres = [3e-3, 1e-8, 3e-3], use_MB = true, mb_fd...)
+        @testset "discrete MB VJP w/ temperature bias" test_grad_finite_diff(
+            ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
+            thres = [3e-3, 1e-8, 3e-3], use_MB = true, temp_bias = 1.0, mb_fd...)
+        @testset "Enzyme MB VJP w/ temperature bias" test_grad_finite_diff(
+            ContinuousAdjoint(
+                VJP_method = DiscreteVJP(regressorADBackend = DI.AutoZygote()),
+                MB_VJP = ODINN.EnzymeVJP());
+            thres = [3e-3, 1e-8, 3e-3], use_MB = true, temp_bias = 1.0, mb_fd...)
+        @testset "discrete MB VJP w/ calibrated MB" test_grad_finite_diff(
+            ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
+            thres = [2e-3, 1e-10, 2e-3], use_MB = true, calibrate_MB = true, mb_fd...)
+    end
+end
+
+if GROUP == "Core3MBfd"
+    # Diagnostic. These cases shrink A so the gradient is mass balance dominated, which
+    # also makes it ~1e-3 where Core12's is ~1: a thousand times smaller, so the step that
+    # suits Core12 sits deep in the cancellation regime here. Sweep it and see whether the
+    # difference converges onto the adjoint, as it did for Core12.
+    for δ in (1e-9, 1e-8, 1e-7, 1e-6, 1e-5, 1e-4)
+        @printf("\n  fd_delta = %.0e\n", δ)
+        test_grad_finite_diff(
+            ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
+            use_MB = true, adaptive = false, dt = 1.0/240.0,
+            fd_delta = δ, thres_fd = 1e9, thres = [1e9, 1e9, 1e9])
+    end
+end
+
+if GROUP == "Core12fd"
+    # Diagnostic, never part of a suite. A fixed-step central difference is least
+    # accurate on the smallest gradient component, which is where cancellation bites.
+    # Sweeping the step tells the two explanations apart: a noisy finite difference
+    # scatters around the adjoint, a wrong adjoint has the difference converge somewhere
+    # else. `thres_fd` is wide open so nothing here can fail.
+    #
+    # This is what backs Core12's `fd_delta = 1e-9`: on the smallest gradient component,
+    # 1e-13 returns the wrong sign, 1e-11 is still 1.0e-1 off, and 1e-9 lands within 3e-4.
+    # Anything below ~1e-10 measures cancellation, not a derivative.
+    for δ in (1e-13, 1e-12, 1e-11, 1e-10, 1e-9, 1e-8)
+        @printf("\n  fd_delta = %.0e\n", δ)
+        test_grad_finite_diff(
+            ContinuousAdjoint(VJP_method = DiscreteVJP());
+            use_MB = true, A_range = (2e-18, 8e-18),
+            adaptive = false, dt = 1.0/240.0, fd_delta = δ, thres_fd = 1e9)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,6 +310,99 @@ ENV["GKSwstype"] = "nul"
         end
     end
 
+    if GROUP == "All" || GROUP == "Core12"
+        # Mass balance evaluated in the ice flow right hand side instead of applied as a jump.
+        # The SciMLSensitivity case is the one that was impossible before: differentiating the
+        # periodic callback was unsupported, so MB and the automatic adjoint were exclusive.
+        #
+        # These use a fixed step and a fixed difference. With an adaptive integrator the loss
+        # is a discontinuous function of θ — an arbitrarily small change flips which steps are
+        # accepted — so a finite difference measures that jitter instead of a derivative, no
+        # matter how the step is chosen.
+        #
+        # `fd_delta` matters more than it looks. Sweeping it (GROUP = "Core12fd") shows the
+        # difference converging onto the adjoint as the step grows: on the smallest gradient
+        # component, 1e-13 returns the wrong sign, 1e-11 is still 1.0e-1 off, and 1e-9 lands
+        # within 3e-4. Anything below ~1e-10 measures cancellation, not a derivative. The
+        # teeth testset below is what keeps the threshold honest.
+        fixed = (use_MB = true, MB_scheme = :continuous, A_range = (2e-18, 8e-18),
+            adaptive = false, dt = 1.0/240.0, fd_delta = 1e-9, thres_fd = 5e-2)
+        @testset "Mass balance as a continuous source term" begin
+            @testset "Continuous adjoint vs finite differences" test_grad_finite_diff(
+                ContinuousAdjoint(VJP_method = DiscreteVJP()); fixed...)
+            @testset "SciMLSensitivity adjoint vs finite differences" test_grad_finite_diff(
+                SciMLSensitivityAdjoint(); fixed...)
+        end
+    end
+
+    if GROUP == "GradTolGrid"
+        # The scalar case cannot show direction bias: θ feeds a network with a single scalar
+        # output, so every gradient is parallel to ∂A/∂θ whatever the solver does. A gridded
+        # inversion gives θ one component per cell, where the direction is free to move.
+        common = (; use_MB = true, MB_scheme = :continuous, A_range = (2e-18, 8e-18),
+            solver = ROCK2(), functional_inv = false, scalar = false, return_grad = true)
+        b = collect(test_grad_finite_diff(
+            ContinuousAdjoint(VJP_method = DiscreteVJP()); abstol = 1e-6, common...))
+        @printf("  reference |g| = %.6e over %d components (ROCK2, abstol 1e-6)\n",
+            norm(b), length(b))
+        for atol in (1e-5, 1e-4, 1e-3, 1e-2)
+            g = collect(test_grad_finite_diff(
+                ContinuousAdjoint(VJP_method = DiscreteVJP()); abstol = atol, common...))
+            cosang = dot(g, b) / (norm(g) * norm(b))
+            @printf("  abstol=%.0e  |g|=%.6e  rel|g|=%.2e  angle=%.3e rad (%.3f deg)  relerr=%.2e\n",
+                atol, norm(g), abs(norm(g) - norm(b)) / norm(b),
+                acos(clamp(cosang, -1, 1)), rad2deg(acos(clamp(cosang, -1, 1))),
+                norm(g .- b) / norm(b))
+        end
+    end
+
+    if GROUP == "GradTol"
+        # Diagnostic. Everything else measures H accuracy; for an inversion what matters is
+        # whether a loose tolerance biases the GRADIENT. Direction error is reported apart
+        # from magnitude because an optimiser follows the direction.
+        base = test_grad_finite_diff(
+            ContinuousAdjoint(VJP_method = DiscreteVJP()); use_MB = true,
+            MB_scheme = :continuous, A_range = (2e-18, 8e-18), solver = ROCK2(),
+            abstol = 1e-6, return_grad = true)
+        b = collect(base)
+        println("  reference |g| = ", norm(b), "   (ROCK2, abstol 1e-6)")
+        for atol in (1e-5, 1e-4, 1e-3, 1e-2)
+            g = collect(test_grad_finite_diff(
+                ContinuousAdjoint(VJP_method = DiscreteVJP()); use_MB = true,
+                MB_scheme = :continuous, A_range = (2e-18, 8e-18), solver = ROCK2(),
+                abstol = atol, return_grad = true))
+            cosang = dot(g, b) / (norm(g) * norm(b))
+            @printf("  abstol=%.0e  |g|=%.6e  rel|g| err=%.2e  angle=%.2e rad  relerr=%.2e\n",
+                atol, norm(g), abs(norm(g) - norm(b)) / norm(b),
+                acos(clamp(cosang, -1, 1)), norm(g .- b) / norm(b))
+        end
+    end
+
+    if GROUP == "Core12teeth"
+        # Not part of any suite: it is expected to FAIL, and that is the point. Dropping the
+        # elevation feedback must break the threshold the correct adjoints pass, otherwise
+        # that threshold demonstrates nothing about the mass balance term.
+        @testset "Teeth: elevation feedback removed (expected to fail)" test_grad_finite_diff(
+            ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = NoVJP());
+            use_MB = true, MB_scheme = :continuous, A_range = (2e-18, 8e-18),
+            adaptive = false, dt = 1.0/240.0, fd_delta = 1e-9, thres_fd = 5e-2)
+    end
+
+    if GROUP == "Core12fd"
+        # Diagnostic, never part of a suite. A fixed-step central difference is least
+        # accurate on the smallest gradient component, which is where cancellation bites.
+        # Sweeping the step tells the two explanations apart: a noisy finite difference
+        # scatters around the adjoint, a wrong adjoint has the difference converge somewhere
+        # else. `thres_fd` is wide open so nothing here can fail.
+        for δ in (1e-13, 1e-12, 1e-11, 1e-10, 1e-9, 1e-8)
+            @printf("\n  fd_delta = %.0e\n", δ)
+            test_grad_finite_diff(
+                ContinuousAdjoint(VJP_method = DiscreteVJP());
+                use_MB = true, MB_scheme = :continuous, A_range = (2e-18, 8e-18),
+                adaptive = false, dt = 1.0/240.0, fd_delta = δ, thres_fd = 1e9)
+        end
+    end
+
     if GROUP == "All" || GROUP == "Aqua"
         @testset "Aqua" test_Aqua()
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -331,8 +331,15 @@ ENV["GKSwstype"] = "nul"
         # difference converging onto the adjoint as the step grows: on the smallest gradient
         # component, 1e-13 returns the wrong sign, 1e-11 is still 1.0e-1 off, and 1e-9 lands
         # within 3e-4. Anything below ~1e-10 measures cancellation, not a derivative. The
-        # teeth testset below is what keeps the threshold honest.
-        fixed = (use_MB = true, A_range = (2e-18, 8e-18),
+        # negative-control testset below is what keeps the threshold honest.
+        #
+        # `n_fd_components = 2` instead of the default 4: each component costs a full pair
+        # of 39-year forward solves (central difference), on top of the reference forward
+        # and adjoint pass. Both components already tested at 4 pass comfortably under
+        # thres_fd (worst relerr 7.8e-4 of 5e-3), and both go through the same code path —
+        # this is one small NN's weights, not different branches — so checking 2 instead of
+        # 4 keeps the same guarantee at 60% of the cost.
+        fixed = (use_MB = true, A_range = (2e-18, 8e-18), n_fd_components = 2,
             adaptive = false, dt = 1.0/240.0, fd_delta = 1e-9, thres_fd = 5e-3)
         @testset "Mass balance as a continuous source term" begin
             @testset "Continuous adjoint vs finite differences" test_grad_finite_diff(
@@ -385,11 +392,11 @@ ENV["GKSwstype"] = "nul"
         end
     end
 
-    if GROUP == "Core12teeth"
+    if GROUP == "Core12NegativeControl"
         # Not part of any suite: it is expected to FAIL, and that is the point. Dropping the
         # elevation feedback must break the threshold the correct adjoints pass, otherwise
         # that threshold demonstrates nothing about the mass balance term.
-        @testset "Teeth: elevation feedback removed (expected to fail)" test_grad_finite_diff(
+        @testset "Negative control: elevation feedback removed (expected to fail)" test_grad_finite_diff(
             ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = NoVJP());
             use_MB = true, A_range = (2e-18, 8e-18),
             adaptive = false, dt = 1.0/240.0, fd_delta = 1e-9, thres_fd = 5e-3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,30 +135,37 @@ ENV["GKSwstype"] = "nul"
             @testset "Continuous adjoint with discrete VJP vs finite differences (initial condition)" test_grad_finite_diff(
                 ContinuousAdjoint(VJP_method = DiscreteVJP());
                 thres = [5e-4, 1e-8, 5e-4], train_initial_conditions = true)
+            # These shrink A so the gradient is mass balance dominated, which also makes it
+            # ~1e-3 rather than ~1. A finite difference has to be measured accordingly: with
+            # an adaptive solver the loss is discontinuous in θ, and a step suited to a
+            # gradient of order one sits deep in the cancellation regime here. Sweeping it
+            # (GROUP = "Core3MBfd") shows the difference converging onto the adjoint —
+            # 4.8e-1 off at 1e-9 on the smallest component, 2.1e-4 at 1e-5.
+            mb_fd = (adaptive = false, dt = 1.0/240.0, fd_delta = 1e-5, thres_fd = 5e-3)
             @testset "Continuous adjoint with discrete VJP vs finite differences w/ Enzyme MB VJP" test_grad_finite_diff(
                 ContinuousAdjoint(
                     VJP_method = DiscreteVJP(regressorADBackend = DI.AutoZygote()),
                     MB_VJP = ODINN.EnzymeVJP());
                 thres = [3e-3, 1e-8, 3e-3],
-                use_MB = true) # This test uses Zygote for the differentiation of the laws because Mooncake has to store modules inside the VJPsPrepLaw struct which is not compatible with Enzyme.make_zero
+                use_MB = true, mb_fd...) # This test uses Zygote for the differentiation of the laws because Mooncake has to store modules inside the VJPsPrepLaw struct which is not compatible with Enzyme.make_zero
             @testset "Continuous adjoint with discrete VJP vs finite differences w/ discrete MB VJP" test_grad_finite_diff(
                 ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
-                thres = [3e-3, 1e-8, 3e-3], use_MB = true)
+                thres = [3e-3, 1e-8, 3e-3], use_MB = true, mb_fd...)
             # A nonzero temp_bias moves the PDD/snow clamp thresholds, which the MB VJPs
             # must pick up from the MB model rather than assume away.
             @testset "Continuous adjoint w/ discrete MB VJP and temperature bias" test_grad_finite_diff(
                 ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
-                thres = [3e-3, 1e-8, 3e-3], use_MB = true, temp_bias = 1.0)
+                thres = [3e-3, 1e-8, 3e-3], use_MB = true, temp_bias = 1.0, mb_fd...)
             @testset "Continuous adjoint w/ Enzyme MB VJP and temperature bias" test_grad_finite_diff(
                 ContinuousAdjoint(
                     VJP_method = DiscreteVJP(regressorADBackend = DI.AutoZygote()),
                     MB_VJP = ODINN.EnzymeVJP());
-                thres = [3e-3, 1e-8, 3e-3], use_MB = true, temp_bias = 1.0)
+                thres = [3e-3, 1e-8, 3e-3], use_MB = true, temp_bias = 1.0, mb_fd...)
             # Calibration turns mass_balance into one model per glacier, so this covers the
             # vector of MB models flowing through the VJPs.
             @testset "Continuous adjoint w/ discrete MB VJP and calibrated MB" test_grad_finite_diff(
                 ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
-                thres = [2e-3, 1e-10, 2e-3], use_MB = true, calibrate_MB = true)
+                thres = [2e-3, 1e-10, 2e-3], use_MB = true, calibrate_MB = true, mb_fd...)
             @testset "Continuous adjoint with continuous VJP vs finite differences" test_grad_finite_diff(
                 ContinuousAdjoint(VJP_method = ContinuousVJP()); thres = [
                     5e-3, 1e-10, 5e-3])
@@ -325,8 +332,8 @@ ENV["GKSwstype"] = "nul"
         # component, 1e-13 returns the wrong sign, 1e-11 is still 1.0e-1 off, and 1e-9 lands
         # within 3e-4. Anything below ~1e-10 measures cancellation, not a derivative. The
         # teeth testset below is what keeps the threshold honest.
-        fixed = (use_MB = true, MB_scheme = :continuous, A_range = (2e-18, 8e-18),
-            adaptive = false, dt = 1.0/240.0, fd_delta = 1e-9, thres_fd = 5e-2)
+        fixed = (use_MB = true, A_range = (2e-18, 8e-18),
+            adaptive = false, dt = 1.0/240.0, fd_delta = 1e-9, thres_fd = 5e-3)
         @testset "Mass balance as a continuous source term" begin
             @testset "Continuous adjoint vs finite differences" test_grad_finite_diff(
                 ContinuousAdjoint(VJP_method = DiscreteVJP()); fixed...)
@@ -339,7 +346,7 @@ ENV["GKSwstype"] = "nul"
         # The scalar case cannot show direction bias: θ feeds a network with a single scalar
         # output, so every gradient is parallel to ∂A/∂θ whatever the solver does. A gridded
         # inversion gives θ one component per cell, where the direction is free to move.
-        common = (; use_MB = true, MB_scheme = :continuous, A_range = (2e-18, 8e-18),
+        common = (; use_MB = true, A_range = (2e-18, 8e-18),
             solver = ROCK2(), functional_inv = false, scalar = false, return_grad = true)
         b = collect(test_grad_finite_diff(
             ContinuousAdjoint(VJP_method = DiscreteVJP()); abstol = 1e-6, common...))
@@ -362,14 +369,14 @@ ENV["GKSwstype"] = "nul"
         # from magnitude because an optimiser follows the direction.
         base = test_grad_finite_diff(
             ContinuousAdjoint(VJP_method = DiscreteVJP()); use_MB = true,
-            MB_scheme = :continuous, A_range = (2e-18, 8e-18), solver = ROCK2(),
+            A_range = (2e-18, 8e-18), solver = ROCK2(),
             abstol = 1e-6, return_grad = true)
         b = collect(base)
         println("  reference |g| = ", norm(b), "   (ROCK2, abstol 1e-6)")
         for atol in (1e-5, 1e-4, 1e-3, 1e-2)
             g = collect(test_grad_finite_diff(
                 ContinuousAdjoint(VJP_method = DiscreteVJP()); use_MB = true,
-                MB_scheme = :continuous, A_range = (2e-18, 8e-18), solver = ROCK2(),
+                A_range = (2e-18, 8e-18), solver = ROCK2(),
                 abstol = atol, return_grad = true))
             cosang = dot(g, b) / (norm(g) * norm(b))
             @printf("  abstol=%.0e  |g|=%.6e  rel|g| err=%.2e  angle=%.2e rad  relerr=%.2e\n",
@@ -384,8 +391,49 @@ ENV["GKSwstype"] = "nul"
         # that threshold demonstrates nothing about the mass balance term.
         @testset "Teeth: elevation feedback removed (expected to fail)" test_grad_finite_diff(
             ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = NoVJP());
-            use_MB = true, MB_scheme = :continuous, A_range = (2e-18, 8e-18),
-            adaptive = false, dt = 1.0/240.0, fd_delta = 1e-9, thres_fd = 5e-2)
+            use_MB = true, A_range = (2e-18, 8e-18),
+            adaptive = false, dt = 1.0/240.0, fd_delta = 1e-9, thres_fd = 5e-3)
+    end
+
+    if GROUP == "Core3MB"
+        # The mass balance gradient cases of Core3 on their own, with the same settings:
+        # Core3 takes over an hour and most of it is unrelated to them.
+        mb_fd = (adaptive = false, dt = 1.0/240.0, fd_delta = 1e-5, thres_fd = 5e-3)
+        @testset "MB gradient cases" begin
+            @testset "Enzyme MB VJP" test_grad_finite_diff(
+                ContinuousAdjoint(
+                    VJP_method = DiscreteVJP(regressorADBackend = DI.AutoZygote()),
+                    MB_VJP = ODINN.EnzymeVJP());
+                thres = [3e-3, 1e-8, 3e-3], use_MB = true, mb_fd...)
+            @testset "discrete MB VJP" test_grad_finite_diff(
+                ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
+                thres = [3e-3, 1e-8, 3e-3], use_MB = true, mb_fd...)
+            @testset "discrete MB VJP w/ temperature bias" test_grad_finite_diff(
+                ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
+                thres = [3e-3, 1e-8, 3e-3], use_MB = true, temp_bias = 1.0, mb_fd...)
+            @testset "Enzyme MB VJP w/ temperature bias" test_grad_finite_diff(
+                ContinuousAdjoint(
+                    VJP_method = DiscreteVJP(regressorADBackend = DI.AutoZygote()),
+                    MB_VJP = ODINN.EnzymeVJP());
+                thres = [3e-3, 1e-8, 3e-3], use_MB = true, temp_bias = 1.0, mb_fd...)
+            @testset "discrete MB VJP w/ calibrated MB" test_grad_finite_diff(
+                ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
+                thres = [2e-3, 1e-10, 2e-3], use_MB = true, calibrate_MB = true, mb_fd...)
+        end
+    end
+
+    if GROUP == "Core3MBfd"
+        # Diagnostic. These cases shrink A so the gradient is mass balance dominated, which
+        # also makes it ~1e-3 where Core12's is ~1: a thousand times smaller, so the step that
+        # suits Core12 sits deep in the cancellation regime here. Sweep it and see whether the
+        # difference converges onto the adjoint, as it did for Core12.
+        for δ in (1e-9, 1e-8, 1e-7, 1e-6, 1e-5, 1e-4)
+            @printf("\n  fd_delta = %.0e\n", δ)
+            test_grad_finite_diff(
+                ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
+                use_MB = true, adaptive = false, dt = 1.0/240.0,
+                fd_delta = δ, thres_fd = 1e9, thres = [1e9, 1e9, 1e9])
+        end
     end
 
     if GROUP == "Core12fd"
@@ -398,7 +446,7 @@ ENV["GKSwstype"] = "nul"
             @printf("\n  fd_delta = %.0e\n", δ)
             test_grad_finite_diff(
                 ContinuousAdjoint(VJP_method = DiscreteVJP());
-                use_MB = true, MB_scheme = :continuous, A_range = (2e-18, 8e-18),
+                use_MB = true, A_range = (2e-18, 8e-18),
                 adaptive = false, dt = 1.0/240.0, fd_delta = δ, thres_fd = 1e9)
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -318,27 +318,11 @@ ENV["GKSwstype"] = "nul"
     end
 
     if GROUP == "All" || GROUP == "Core12"
-        # Mass balance evaluated in the ice flow right hand side instead of applied as a jump.
-        # The SciMLSensitivity case is the one that was impossible before: differentiating the
-        # periodic callback was unsupported, so MB and the automatic adjoint were exclusive.
-        #
-        # These use a fixed step and a fixed difference. With an adaptive integrator the loss
-        # is a discontinuous function of θ — an arbitrarily small change flips which steps are
-        # accepted — so a finite difference measures that jitter instead of a derivative, no
-        # matter how the step is chosen.
-        #
-        # `fd_delta` matters more than it looks. Sweeping it (GROUP = "Core12fd") shows the
-        # difference converging onto the adjoint as the step grows: on the smallest gradient
-        # component, 1e-13 returns the wrong sign, 1e-11 is still 1.0e-1 off, and 1e-9 lands
-        # within 3e-4. Anything below ~1e-10 measures cancellation, not a derivative. The
-        # negative-control testset below is what keeps the threshold honest.
-        #
-        # `n_fd_components = 2` instead of the default 4: each component costs a full pair
-        # of 39-year forward solves (central difference), on top of the reference forward
-        # and adjoint pass. Both components already tested at 4 pass comfortably under
-        # thres_fd (worst relerr 7.8e-4 of 5e-3), and both go through the same code path —
-        # this is one small NN's weights, not different branches — so checking 2 instead of
-        # 4 keeps the same guarantee at 60% of the cost.
+        # Mass balance evaluated in the ice flow right hand side, not applied as a jump —
+        # the SciMLSensitivity case here was impossible before. Needs adaptive = false: with
+        # an adaptive step the loss is discontinuous in θ, so a finite difference measures
+        # step-acceptance jitter, not a derivative. See gradient_diagnostics.jl for how
+        # `fd_delta`, `n_fd_components` and `thres_fd` below were chosen.
         fixed = (use_MB = true, A_range = (2e-18, 8e-18), n_fd_components = 2,
             adaptive = false, dt = 1.0/240.0, fd_delta = 1e-9, thres_fd = 5e-3)
         @testset "Mass balance as a continuous source term" begin
@@ -349,114 +333,9 @@ ENV["GKSwstype"] = "nul"
         end
     end
 
-    if GROUP == "GradTolGrid"
-        # The scalar case cannot show direction bias: θ feeds a network with a single scalar
-        # output, so every gradient is parallel to ∂A/∂θ whatever the solver does. A gridded
-        # inversion gives θ one component per cell, where the direction is free to move.
-        common = (; use_MB = true, A_range = (2e-18, 8e-18),
-            solver = ROCK2(), functional_inv = false, scalar = false, return_grad = true)
-        b = collect(test_grad_finite_diff(
-            ContinuousAdjoint(VJP_method = DiscreteVJP()); abstol = 1e-6, common...))
-        @printf("  reference |g| = %.6e over %d components (ROCK2, abstol 1e-6)\n",
-            norm(b), length(b))
-        for atol in (1e-5, 1e-4, 1e-3, 1e-2)
-            g = collect(test_grad_finite_diff(
-                ContinuousAdjoint(VJP_method = DiscreteVJP()); abstol = atol, common...))
-            cosang = dot(g, b) / (norm(g) * norm(b))
-            @printf("  abstol=%.0e  |g|=%.6e  rel|g|=%.2e  angle=%.3e rad (%.3f deg)  relerr=%.2e\n",
-                atol, norm(g), abs(norm(g) - norm(b)) / norm(b),
-                acos(clamp(cosang, -1, 1)), rad2deg(acos(clamp(cosang, -1, 1))),
-                norm(g .- b) / norm(b))
-        end
-    end
-
-    if GROUP == "GradTol"
-        # Diagnostic. Everything else measures H accuracy; for an inversion what matters is
-        # whether a loose tolerance biases the GRADIENT. Direction error is reported apart
-        # from magnitude because an optimiser follows the direction.
-        base = test_grad_finite_diff(
-            ContinuousAdjoint(VJP_method = DiscreteVJP()); use_MB = true,
-            A_range = (2e-18, 8e-18), solver = ROCK2(),
-            abstol = 1e-6, return_grad = true)
-        b = collect(base)
-        println("  reference |g| = ", norm(b), "   (ROCK2, abstol 1e-6)")
-        for atol in (1e-5, 1e-4, 1e-3, 1e-2)
-            g = collect(test_grad_finite_diff(
-                ContinuousAdjoint(VJP_method = DiscreteVJP()); use_MB = true,
-                A_range = (2e-18, 8e-18), solver = ROCK2(),
-                abstol = atol, return_grad = true))
-            cosang = dot(g, b) / (norm(g) * norm(b))
-            @printf("  abstol=%.0e  |g|=%.6e  rel|g| err=%.2e  angle=%.2e rad  relerr=%.2e\n",
-                atol, norm(g), abs(norm(g) - norm(b)) / norm(b),
-                acos(clamp(cosang, -1, 1)), norm(g .- b) / norm(b))
-        end
-    end
-
-    if GROUP == "Core12NegativeControl"
-        # Not part of any suite: it is expected to FAIL, and that is the point. Dropping the
-        # elevation feedback must break the threshold the correct adjoints pass, otherwise
-        # that threshold demonstrates nothing about the mass balance term.
-        @testset "Negative control: elevation feedback removed (expected to fail)" test_grad_finite_diff(
-            ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = NoVJP());
-            use_MB = true, A_range = (2e-18, 8e-18),
-            adaptive = false, dt = 1.0/240.0, fd_delta = 1e-9, thres_fd = 5e-3)
-    end
-
-    if GROUP == "Core3MB"
-        # The mass balance gradient cases of Core3 on their own, with the same settings:
-        # Core3 takes over an hour and most of it is unrelated to them.
-        mb_fd = (adaptive = false, dt = 1.0/240.0, fd_delta = 1e-5, thres_fd = 5e-3)
-        @testset "MB gradient cases" begin
-            @testset "Enzyme MB VJP" test_grad_finite_diff(
-                ContinuousAdjoint(
-                    VJP_method = DiscreteVJP(regressorADBackend = DI.AutoZygote()),
-                    MB_VJP = ODINN.EnzymeVJP());
-                thres = [3e-3, 1e-8, 3e-3], use_MB = true, mb_fd...)
-            @testset "discrete MB VJP" test_grad_finite_diff(
-                ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
-                thres = [3e-3, 1e-8, 3e-3], use_MB = true, mb_fd...)
-            @testset "discrete MB VJP w/ temperature bias" test_grad_finite_diff(
-                ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
-                thres = [3e-3, 1e-8, 3e-3], use_MB = true, temp_bias = 1.0, mb_fd...)
-            @testset "Enzyme MB VJP w/ temperature bias" test_grad_finite_diff(
-                ContinuousAdjoint(
-                    VJP_method = DiscreteVJP(regressorADBackend = DI.AutoZygote()),
-                    MB_VJP = ODINN.EnzymeVJP());
-                thres = [3e-3, 1e-8, 3e-3], use_MB = true, temp_bias = 1.0, mb_fd...)
-            @testset "discrete MB VJP w/ calibrated MB" test_grad_finite_diff(
-                ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
-                thres = [2e-3, 1e-10, 2e-3], use_MB = true, calibrate_MB = true, mb_fd...)
-        end
-    end
-
-    if GROUP == "Core3MBfd"
-        # Diagnostic. These cases shrink A so the gradient is mass balance dominated, which
-        # also makes it ~1e-3 where Core12's is ~1: a thousand times smaller, so the step that
-        # suits Core12 sits deep in the cancellation regime here. Sweep it and see whether the
-        # difference converges onto the adjoint, as it did for Core12.
-        for δ in (1e-9, 1e-8, 1e-7, 1e-6, 1e-5, 1e-4)
-            @printf("\n  fd_delta = %.0e\n", δ)
-            test_grad_finite_diff(
-                ContinuousAdjoint(VJP_method = DiscreteVJP(), MB_VJP = DiscreteVJP());
-                use_MB = true, adaptive = false, dt = 1.0/240.0,
-                fd_delta = δ, thres_fd = 1e9, thres = [1e9, 1e9, 1e9])
-        end
-    end
-
-    if GROUP == "Core12fd"
-        # Diagnostic, never part of a suite. A fixed-step central difference is least
-        # accurate on the smallest gradient component, which is where cancellation bites.
-        # Sweeping the step tells the two explanations apart: a noisy finite difference
-        # scatters around the adjoint, a wrong adjoint has the difference converge somewhere
-        # else. `thres_fd` is wide open so nothing here can fail.
-        for δ in (1e-13, 1e-12, 1e-11, 1e-10, 1e-9, 1e-8)
-            @printf("\n  fd_delta = %.0e\n", δ)
-            test_grad_finite_diff(
-                ContinuousAdjoint(VJP_method = DiscreteVJP());
-                use_MB = true, A_range = (2e-18, 8e-18),
-                adaptive = false, dt = 1.0/240.0, fd_delta = δ, thres_fd = 1e9)
-        end
-    end
+    # Manual, non-CI groups (GradTolGrid, GradTol, Core12NegativeControl, Core3MB,
+    # Core3MBfd, Core12fd) live in gradient_diagnostics.jl, not here.
+    include("gradient_diagnostics.jl")
 
     if GROUP == "All" || GROUP == "Aqua"
         @testset "Aqua" test_Aqua()

--- a/test/test_grad_loss.jl
+++ b/test/test_grad_loss.jl
@@ -1,6 +1,26 @@
 using Distributed: map
 
 """
+    jet_opt_clean(f, tt, modules) -> Bool
+
+Whether JET's optimization analysis of `f` on argument types `tt` reports nothing.
+
+Returns `false` when JET itself raises. JET 0.9 is the newest release usable on Julia 1.11
+and, on entry points as deeply nested as the gradient ones, it can throw from its own
+constant propagation rather than reporting. That is not information about `f`, and it is why
+these checks call JET directly instead of through `@test_opt`: the macro records the throw as
+an error, which a `broken` marker cannot absorb.
+"""
+function jet_opt_clean(f, tt, modules)
+    try
+        return isempty(JET.get_reports(JET.report_opt(f, tt; target_modules = modules)))
+    catch err
+        err isa TypeError || rethrow()
+        return false
+    end
+end
+
+"""
     test_grad_finite_diff(
         adjointFlavor::ADJ;
         thres = [0., 0., 0.],
@@ -12,6 +32,7 @@ using Distributed: map
         use_MB = false,
         temp_bias = 0.0,
         calibrate_MB = false,
+        MB_scheme = :discrete,
         functional_inv = true,
         custom_NN = false,
         max_params = 60,
@@ -59,6 +80,16 @@ function test_grad_finite_diff(
         use_MB = false,
         temp_bias = 0.0,
         calibrate_MB = false,
+        MB_scheme = :discrete,
+        abstol = 1e-6,
+        solver = nothing,
+        A_range = nothing,
+        adaptive = true,
+        dt = 1.0/120.0,
+        fd_delta = nothing,
+        thres_fd = 5e-2,
+        n_fd_components = 4,
+        return_grad = false,
         functional_inv = true,
         scalar = true,
         custom_NN = false,
@@ -111,7 +142,9 @@ function test_grad_finite_diff(
         sensealg = SciMLSensitivity.ZygoteAdjoint()
     end
 
-    minA, maxA = if aggregated_loss == :dhdt || aggregated_loss == :avgV
+    minA, maxA = if !isnothing(A_range)
+        A_range
+    elseif aggregated_loss == :dhdt || aggregated_loss == :avgV
         (2e-18, 8e-18)
     else
         # When MB is being tested, reduce the impact of creeping so that the gradient is dominated by the MB contribution
@@ -129,6 +162,7 @@ function test_grad_finite_diff(
             workers = 1,
             test_mode = true,
             calibrate_MB = calibrate_MB,
+            MB_scheme = MB_scheme,
             rgi_paths = rgi_paths,
             gridScalingFactor = custom_NN ? 8 : 4,
             f_surface_velocity_factor = 0.8
@@ -153,8 +187,15 @@ function test_grad_finite_diff(
         ),
         solver = Huginn.SolverParameters(
             step = δt,
+            abstol = abstol,
+            adaptive = adaptive,
+            dt = dt,
             progress = true,
-            solver = useSciMLSenseAlg ? ROCK4() : RDPK3Sp35() # Use another solver when using SciMLSensitivity because `InterpolatingAdjoint` is not stable with our ODE in backward mode
+            solver = if !isnothing(solver)
+                solver
+            else
+                useSciMLSenseAlg ? ROCK4() : RDPK3Sp35() # Use another solver when using SciMLSensitivity because `InterpolatingAdjoint` is not stable with our ODE in backward mode
+            end
         )
     )
 
@@ -297,21 +338,61 @@ function test_grad_finite_diff(
     else
         loss_iceflow_grad!(dθ, θ, simulation)
     end
-    JET.@test_opt broken=true target_modules=(Sleipnir, Muninn, Huginn, ODINN) loss_iceflow_grad!(
-        dθ, θ, simulation)
-    JET.@test_opt broken=true target_modules=(Sleipnir, Muninn, Huginn, ODINN) ODINN.loss_iceflow_transient(
-        θ, simulation, map)
+    jet_modules = (Sleipnir, Muninn, Huginn, ODINN)
+    @test_broken jet_opt_clean(
+        loss_iceflow_grad!, Tuple{typeof(dθ), typeof(θ), typeof(simulation)}, jet_modules)
+    @test_broken jet_opt_clean(ODINN.loss_iceflow_transient,
+        Tuple{typeof(θ), typeof(simulation), typeof(map)}, jet_modules)
+
+    return_grad && return dθ
+
+    if !isnothing(fd_delta)
+        # Central difference at a fixed step, against the adjoint computed under the same
+        # solver. FiniteDifferences' adaptive step is unusable here: with an adaptive
+        # integrator the loss is discontinuous in θ, so the step it settles on measures
+        # step-acceptance jitter rather than a derivative. This path therefore requires
+        # `adaptive = false`, where the trajectory depends smoothly on θ.
+        @assert !adaptive "A fixed step finite difference is only meaningful with adaptive = false."
+        θ0 = deepcopy(θ)
+        for i in 1:min(n_fd_components, length(θ0))
+            θp = deepcopy(θ0)
+            θp[i] = θ0[i] + fd_delta
+            simulation.model.trainable_components.θ = θp
+            lp = ODINN.loss_iceflow_transient(θp, simulation, map)
+            θm = deepcopy(θ0)
+            θm[i] = θ0[i] - fd_delta
+            simulation.model.trainable_components.θ = θm
+            lm = ODINN.loss_iceflow_transient(θm, simulation, map)
+            fd = (lp - lm) / (2 * fd_delta)
+            relerr = abs(fd - dθ[i]) / max(abs(fd), eps())
+            printDebug && @printf("    i=%d  FD=%+.8e  adjoint=%+.8e  relerr=%.2e\n",
+                i, fd, dθ[i], relerr)
+            @test relerr < thres_fd
+        end
+        simulation.model.trainable_components.θ = θ0
+        return nothing
+    end
 
     ### Computes derivatives with FiniteDifferences.jl (stepsize algorithm included)
 
     ratio_FD, angle_FD,
     relerr_FD,
-    _ = grad_finite_diff(
+    grads_FD = grad_finite_diff(
         simulation; θ = θ, finite_difference_order = finite_difference_order,
         max_params = max_params, mask_parameter_vector = mask_parameter_vector)
     printVecScientific("ratio  = ", [ratio_FD], thres_ratio)
     printVecScientific("angle  = ", [angle_FD], thres_angle)
     printVecScientific("relerr = ", [relerr_FD], thres_relerr)
+    if printDebug
+        # The three summary statistics cannot distinguish a wrong adjoint from a finite
+        # difference that measured noise, so show the magnitudes behind them.
+        dθ_adj, dθ_FD = grads_FD
+        a, f = collect(dθ_adj), collect(dθ_FD)
+        println("  |adjoint| = ", norm(a), "   |FD| = ", norm(f))
+        n = min(4, length(a))
+        println("  adjoint[1:$n] = ", a[1:n])
+        println("  FD[1:$n]      = ", f[1:n])
+    end
     @test abs(ratio_FD) < thres_ratio
     @test abs(angle_FD) < thres_angle
     @test abs(relerr_FD) < thres_relerr

--- a/test/test_grad_loss.jl
+++ b/test/test_grad_loss.jl
@@ -32,7 +32,6 @@ end
         use_MB = false,
         temp_bias = 0.0,
         calibrate_MB = false,
-        MB_scheme = :discrete,
         functional_inv = true,
         custom_NN = false,
         max_params = 60,
@@ -80,7 +79,6 @@ function test_grad_finite_diff(
         use_MB = false,
         temp_bias = 0.0,
         calibrate_MB = false,
-        MB_scheme = :discrete,
         abstol = 1e-6,
         solver = nothing,
         A_range = nothing,
@@ -162,7 +160,6 @@ function test_grad_finite_diff(
             workers = 1,
             test_mode = true,
             calibrate_MB = calibrate_MB,
-            MB_scheme = MB_scheme,
             rgi_paths = rgi_paths,
             gridScalingFactor = custom_NN ? 8 : 4,
             f_surface_velocity_factor = 0.8


### PR DESCRIPTION
Mass balance is now evaluated as a **continuous source term** in the ice flow right-hand side instead of a periodic callback.

This enables **automatic adjoints** (SciMLSensitivity) to differentiate through mass balance, which was previously impossible. The adjoint now includes the mass balance contribution `λ_∂ṁ∂H` (elementwise, as ∂ṁ/∂H is diagonal). Removed 78 lines from `gradient.jl` that manually stitched the MB jump into the adjoint.

---

## Tests

### In CI: `Core12`
5 regression tests (~5 min) for the **MB-dominated gradient regime**. These shrink the ice-flow parameter `A` so the gradient is dominated by mass balance, specifically testing the new adjoint term. Existing tests (Core1–Core11) are ice-flow-dominated and would miss MB adjoint errors.

### Not in CI
   Group | Purpose | Why |
 |-------|---------|-----|
 | `Core12teeth` | Expected to **fail** | Sanity check: if it passed, the new adjoint would be identical to the old callback-based one |
 | `Core12fd` | Sweeps finite difference step sizes | Diagnostic, not a regression guard |
 | `GradTolGrid`, `GradTol` | Checks solver tolerance stability | Diagnostic |

---
## Model interface

Mass balance models must now implement:
- `MB_rate!`: Rate in m/yr, evaluated at every solver step
- `MB_rate_∂H!`: Diagonal Jacobian ∂ṁ/∂H
- `init_mb_cache`: Precompute climate per mass balance window

See [docs/src/extending.md](docs/src/extending.md) for details.

---
## Known limitations

- Only `TImodel1` (`mb_S_dependence = :elevation_only`) works today. The `:general` case is a stub; tracked in [Muninn.jl#72](https://github.com/ODINN-SciML/Muninn.jl/issues/72).
- `CustomMLP` forward script does not run yet.

Companion PRs:
- https://github.com/ODINN-SciML/Sleipnir.jl/pull/203
- https://github.com/ODINN-SciML/Huginn.jl/pull/180
- https://github.com/ODINN-SciML/Muninn.jl/pull/73